### PR TITLE
Implementation fixes for OLE string conversions. Closes #34

### DIFF
--- a/com.go
+++ b/com.go
@@ -98,7 +98,7 @@ func StringFromCLSID(clsid *GUID) (str string, err error) {
 	if hr != 0 {
 		err = NewError(hr)
 	}
-	str = UTF16PtrToString(p)
+	str = LpOleStrToString(p)
 	return
 }
 
@@ -119,7 +119,7 @@ func StringFromIID(iid *GUID) (str string, err error) {
 	if hr != 0 {
 		err = NewError(hr)
 	}
-	str = UTF16PtrToString(p)
+	str = LpOleStrToString(p)
 	return
 }
 

--- a/idispatch.go
+++ b/idispatch.go
@@ -204,7 +204,7 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 		if excepInfo.bstrDescription == nil {
 			err = NewError(hr)
 		} else {
-			bs := UTF16PtrToString(excepInfo.bstrDescription)
+			bs := BstrToString(excepInfo.bstrDescription)
 			err = NewErrorWithDescription(hr, bs)
 		}
 	}
@@ -214,7 +214,7 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 		}
 		/*
 			if varg.VT == (VT_BSTR|VT_BYREF) && varg.Val != 0 {
-				*(params[n].(*string)) = UTF16PtrToString((*uint16)(unsafe.Pointer(uintptr(varg.Val))))
+				*(params[n].(*string)) = LpOleStrToString((*uint16)(unsafe.Pointer(uintptr(varg.Val))))
 				println(*(params[n].(*string)))
 				fmt.Fprintln(os.Stderr, *(params[n].(*string)))
 			}

--- a/ole.go
+++ b/ole.go
@@ -86,7 +86,7 @@ func (v *VARIANT) ToArray() *SafeArrayConversion {
 }
 
 func (v *VARIANT) ToString() string {
-	return UTF16PtrToString(*(**uint16)(unsafe.Pointer(&v.Val)))
+	return BstrToString(*(**uint16)(unsafe.Pointer(&v.Val)))
 }
 
 func (v *VARIANT) Clear() error {

--- a/oleutil/oleutil.go
+++ b/oleutil/oleutil.go
@@ -147,7 +147,7 @@ func dispGetIDsOfNames(this *ole.IUnknown, iid *ole.GUID, wnames []*uint16, name
 	pthis := (*stdDispatch)(unsafe.Pointer(this))
 	names := make([]string, len(wnames))
 	for i := 0; i < len(names); i++ {
-		names[i] = ole.UTF16PtrToString(wnames[i])
+		names[i] = ole.LpOleStrToString(wnames[i])
 	}
 	for n := 0; n < namelen; n++ {
 		if id, ok := pthis.funcMap[names[n]]; ok {

--- a/safearray.go
+++ b/safearray.go
@@ -171,7 +171,7 @@ func safeArrayGetElementString(safearray *SafeArray, index int64) (str string, e
 			uintptr(unsafe.Pointer(safearray)),
 			uintptr(unsafe.Pointer(&index)),
 			uintptr(unsafe.Pointer(&element))))
-	str = UTF16PtrToString(*(**uint16)(unsafe.Pointer(&element)))
+	str = BstrToString(*(**uint16)(unsafe.Pointer(&element)))
 	SysFreeString(element)
 	return
 }


### PR DESCRIPTION
- Remove 10,000 character limit on string-conversion functions by dynamically getting size of original string
- Split UTF16PtrToString into two separate functions, one for LPOLESTR's (LpOleStrToString)
  and one for BSTR's (BstrToString), since some Windows/COM functions use one type or the other
- Keep UTF16PtrToString as an alias for LpOleStrToString, to keep ole package API compatible with previous versions
- Refactor library code to use either LpOleStrToString or BStrToString, as appropriate
