### PR TITLE
Fixes SysAllocStringLen to handle empty strings without causing panic.

### DIFF
--- a/com.go
+++ b/com.go
@@ -176,10 +176,10 @@ func SysAllocString(v string) (ss *int16) {
 }
 
 func SysAllocStringLen(v string) (ss *int16) {
-	utf16 := utf16.Encode([]rune(v))
+	utf16 := utf16.Encode([]rune(v + "\x00"))
 	ptr := &utf16[0]
 
-	pss, _, _ := procSysAllocStringLen.Call(uintptr(unsafe.Pointer(ptr)), uintptr(len(utf16)))
+	pss, _, _ := procSysAllocStringLen.Call(uintptr(unsafe.Pointer(ptr)), uintptr(len(utf16)-1))
 	ss = (*int16)(unsafe.Pointer(pss))
 	return
 }


### PR DESCRIPTION
This fixes issue #41.

The problem was that the code converts the passed-in string to UTF16, which means converting it to a slice of uint16's. The code then needs to get the address of the first character in this slice, in order to pass the pointer to the real `SysAllocStringLen` function in Windows.

Since the slice will be empty for an empty string, the code to get the pointer (`&utf16[0]`) panics because the slice is empty.

This was fixed by appending an extra null character to the string before it is converted to UTF16, so that the resulting slice will always contain at least character. 1 character is then subtracted from the length of the string to allocate, so the extra character is not included in the copy of the string that Windows allocates.
