### PR TITLE
Model COM class inheritence (help DRY-up code)

### DIFF
--- a/iconnectionpointcontainer.go
+++ b/iconnectionpointcontainer.go
@@ -6,28 +6,17 @@ import (
 )
 
 type IConnectionPointContainer struct {
-	lpVtbl *pIConnectionPointContainerVtbl
+	IUnknown
 }
 
-type pIConnectionPointContainerVtbl struct {
-	pQueryInterface       uintptr
-	pAddRef               uintptr
-	pRelease              uintptr
-	pEnumConnectionPoints uintptr
-	pFindConnectionPoint  uintptr
+type IConnectionPointContainerVtbl struct {
+	IUnknownVtbl
+	EnumConnectionPoints uintptr
+	FindConnectionPoint  uintptr
 }
 
-func (v *IConnectionPointContainer) QueryInterface(iid *GUID) (disp *IDispatch, err error) {
-	disp, err = queryInterface((*IUnknown)(unsafe.Pointer(v)), iid)
-	return
-}
-
-func (v *IConnectionPointContainer) AddRef() int32 {
-	return addRef((*IUnknown)(unsafe.Pointer(v)))
-}
-
-func (v *IConnectionPointContainer) Release() int32 {
-	return release((*IUnknown)(unsafe.Pointer(v)))
+func (v *IConnectionPointContainer) VTable() *IConnectionPointContainerVtbl {
+	return (*IConnectionPointContainerVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
 func (v *IConnectionPointContainer) EnumConnectionPoints(points interface{}) (err error) {
@@ -37,7 +26,7 @@ func (v *IConnectionPointContainer) EnumConnectionPoints(points interface{}) (er
 
 func (v *IConnectionPointContainer) FindConnectionPoint(iid *GUID, point **IConnectionPoint) (err error) {
 	hr, _, _ := syscall.Syscall(
-		uintptr(v.lpVtbl.pFindConnectionPoint),
+		v.VTable().FindConnectionPoint,
 		3,
 		uintptr(unsafe.Pointer(v)),
 		uintptr(unsafe.Pointer(iid)),

--- a/idispatch.go
+++ b/idispatch.go
@@ -6,35 +6,19 @@ import (
 )
 
 type IDispatch struct {
-	lpVtbl *pIDispatchVtbl
+	IUnknown
 }
 
-type pIDispatchVtbl struct {
-	pQueryInterface   uintptr
-	pAddRef           uintptr
-	pRelease          uintptr
-	pGetTypeInfoCount uintptr
-	pGetTypeInfo      uintptr
-	pGetIDsOfNames    uintptr
-	pInvoke           uintptr
+type IDispatchVtbl struct {
+	IUnknownVtbl
+	GetTypeInfoCount uintptr
+	GetTypeInfo      uintptr
+	GetIDsOfNames    uintptr
+	Invoke           uintptr
 }
 
-func (v *IDispatch) QueryInterface(iid *GUID) (disp *IDispatch, err error) {
-	disp, err = queryInterface((*IUnknown)(unsafe.Pointer(v)), iid)
-	return
-}
-
-func (v *IDispatch) MustQueryInterface(iid *GUID) (disp *IDispatch) {
-	disp, _ = queryInterface((*IUnknown)(unsafe.Pointer(v)), iid)
-	return
-}
-
-func (v *IDispatch) AddRef() int32 {
-	return addRef((*IUnknown)(unsafe.Pointer(v)))
-}
-
-func (v *IDispatch) Release() int32 {
-	return release((*IUnknown)(unsafe.Pointer(v)))
+func (v *IDispatch) VTable() *IDispatchVtbl {
+	return (*IDispatchVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
 func (v *IDispatch) GetIDsOfName(names []string) (dispid []int32, err error) {
@@ -65,7 +49,7 @@ func getIDsOfName(disp *IDispatch, names []string) (dispid []int32, err error) {
 	dispid = make([]int32, len(names))
 	namelen := uint32(len(names))
 	hr, _, _ := syscall.Syscall6(
-		disp.lpVtbl.pGetIDsOfNames,
+		disp.VTable().GetIDsOfNames,
 		6,
 		uintptr(unsafe.Pointer(disp)),
 		uintptr(unsafe.Pointer(IID_NULL)),
@@ -81,7 +65,7 @@ func getIDsOfName(disp *IDispatch, names []string) (dispid []int32, err error) {
 
 func getTypeInfoCount(disp *IDispatch) (c uint32, err error) {
 	hr, _, _ := syscall.Syscall(
-		disp.lpVtbl.pGetTypeInfoCount,
+		disp.VTable().GetTypeInfoCount,
 		2,
 		uintptr(unsafe.Pointer(disp)),
 		uintptr(unsafe.Pointer(&c)),
@@ -94,7 +78,7 @@ func getTypeInfoCount(disp *IDispatch) (c uint32, err error) {
 
 func getTypeInfo(disp *IDispatch) (tinfo *ITypeInfo, err error) {
 	hr, _, _ := syscall.Syscall(
-		disp.lpVtbl.pGetTypeInfo,
+		disp.VTable().GetTypeInfo,
 		3,
 		uintptr(unsafe.Pointer(disp)),
 		uintptr(GetUserDefaultLCID()),
@@ -193,7 +177,7 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 	var excepInfo EXCEPINFO
 	VariantInit(result)
 	hr, _, _ := syscall.Syscall9(
-		disp.lpVtbl.pInvoke,
+		disp.VTable().Invoke,
 		9,
 		uintptr(unsafe.Pointer(disp)),
 		uintptr(dispid),

--- a/iprovideclassinfo.go
+++ b/iprovideclassinfo.go
@@ -6,27 +6,16 @@ import (
 )
 
 type IProvideClassInfo struct {
-	lpVtbl *pIProvideClassInfoVtbl
+	IUnknown
 }
 
-type pIProvideClassInfoVtbl struct {
-	pQueryInterface uintptr
-	pAddRef         uintptr
-	pRelease        uintptr
-	pGetClassInfo   uintptr
+type IProvideClassInfoVtbl struct {
+	IUnknownVtbl
+	GetClassInfo uintptr
 }
 
-func (v *IProvideClassInfo) QueryInterface(iid *GUID) (disp *IDispatch, err error) {
-	disp, err = queryInterface((*IUnknown)(unsafe.Pointer(v)), iid)
-	return
-}
-
-func (v *IProvideClassInfo) AddRef() int32 {
-	return addRef((*IUnknown)(unsafe.Pointer(v)))
-}
-
-func (v *IProvideClassInfo) Release() int32 {
-	return release((*IUnknown)(unsafe.Pointer(v)))
+func (v *IProvideClassInfo) VTable() *IProvideClassInfoVtbl {
+	return (*IProvideClassInfoVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
 func (v *IProvideClassInfo) GetClassInfo() (cinfo *ITypeInfo, err error) {
@@ -36,7 +25,7 @@ func (v *IProvideClassInfo) GetClassInfo() (cinfo *ITypeInfo, err error) {
 
 func getClassInfo(disp *IProvideClassInfo) (tinfo *ITypeInfo, err error) {
 	hr, _, _ := syscall.Syscall(
-		disp.lpVtbl.pGetClassInfo,
+		disp.VTable().GetClassInfo,
 		2,
 		uintptr(unsafe.Pointer(disp)),
 		uintptr(unsafe.Pointer(&tinfo)),

--- a/itypeinfo.go
+++ b/itypeinfo.go
@@ -6,50 +6,39 @@ import (
 )
 
 type ITypeInfo struct {
-	lpVtbl *pITypeInfoVtbl
+	IUnknown
 }
 
-type pITypeInfoVtbl struct {
-	pQueryInterface       uintptr
-	pAddRef               uintptr
-	pRelease              uintptr
-	pGetTypeAttr          uintptr
-	pGetTypeComp          uintptr
-	pGetFuncDesc          uintptr
-	pGetVarDesc           uintptr
-	pGetNames             uintptr
-	pGetRefTypeOfImplType uintptr
-	pGetImplTypeFlags     uintptr
-	pGetIDsOfNames        uintptr
-	pInvoke               uintptr
-	pGetDocumentation     uintptr
-	pGetDllEntry          uintptr
-	pGetRefTypeInfo       uintptr
-	pAddressOfMember      uintptr
-	pCreateInstance       uintptr
-	pGetMops              uintptr
-	pGetContainingTypeLib uintptr
-	pReleaseTypeAttr      uintptr
-	pReleaseFuncDesc      uintptr
-	pReleaseVarDesc       uintptr
+type ITypeInfoVtbl struct {
+	IUnknownVtbl
+	GetTypeAttr          uintptr
+	GetTypeComp          uintptr
+	GetFuncDesc          uintptr
+	GetVarDesc           uintptr
+	GetNames             uintptr
+	GetRefTypeOfImplType uintptr
+	GetImplTypeFlags     uintptr
+	GetIDsOfNames        uintptr
+	Invoke               uintptr
+	GetDocumentation     uintptr
+	GetDllEntry          uintptr
+	GetRefTypeInfo       uintptr
+	AddressOfMember      uintptr
+	CreateInstance       uintptr
+	GetMops              uintptr
+	GetContainingTypeLib uintptr
+	ReleaseTypeAttr      uintptr
+	ReleaseFuncDesc      uintptr
+	ReleaseVarDesc       uintptr
 }
 
-func (v *ITypeInfo) QueryInterface(iid *GUID) (disp *IDispatch, err error) {
-	disp, err = queryInterface((*IUnknown)(unsafe.Pointer(v)), iid)
-	return
-}
-
-func (v *ITypeInfo) AddRef() int32 {
-	return addRef((*IUnknown)(unsafe.Pointer(v)))
-}
-
-func (v *ITypeInfo) Release() int32 {
-	return release((*IUnknown)(unsafe.Pointer(v)))
+func (v *ITypeInfo) VTable() *ITypeInfoVtbl {
+	return (*ITypeInfoVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
 func (v *ITypeInfo) GetTypeAttr() (tattr *TYPEATTR, err error) {
 	hr, _, _ := syscall.Syscall(
-		uintptr(v.lpVtbl.pGetTypeAttr),
+		uintptr(v.VTable().GetTypeAttr),
 		2,
 		uintptr(unsafe.Pointer(v)),
 		uintptr(unsafe.Pointer(&tattr)),


### PR DESCRIPTION
This PR attempts to remove duplication by modeling the COM class inheritance.

It works by exposing the vtable on the base IUnknown class as an opaque *interface{}.  Each COM class then implements a VTable() func that casts the opaque pointer to that class's specific vtable type.  The vtables themselves embed their parent class's vtable definition, which removes duplication.

The result is the ability to extend parent vtables without re-listing the parent methods, and the ability to call parent methods without re-defining the methods.
