### PR TITLE
Fix package reference in oleutil.

### DIFF
--- a/oleutil/oleutil.go
+++ b/oleutil/oleutil.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/mattn/go-ole"
+	"github.com/go-ole"
 )
 
 func CreateObject(progId string) (unknown *ole.IUnknown, err error) {


### PR DESCRIPTION
The oleutil package was still referencing the [old mattn/go-ole repo](https://github.com/mattn). This makes it use the [current go-ole project](https://github.com/go-ole).