### PR TITLE
Complete initial appveyor build. Only 64-bit works with pull request.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 #   - All section names are case-sensitive.
 #   - Section names should be unique on each level.
 
-version: "{branch}.{build}"
+version: "1.2.0.{build}-alpha-{branch}"
 
 os: Windows Server 2012 R2
 
@@ -23,20 +23,45 @@ environment:
   matrix:
   - GOARCH: amd64
     GOVERSION: 1.4
+    GOROOT: c:\go
+    DOWNLOADPLATFORM: "x64"
+  - GOARCH: 386
+    GOVERSION: 1.4
+    GOROOT: c:\go-x86
+    GOTOOLDIR: c:\go
+    DOWNLOADPLATFORM: "x86"
+
+matrix:
+  fast_finish: true
 
 install:
-  # - echo %PATH%
-  - echo %GOPATH%
+  - choco install mingw
+  - SET PATH=c:\tools\mingw64\bin;%PATH%
+  - ECHO %PATH%
+  # - Download COM Server
+  - ps: Start-FileDownload "https://github.com/jacobsantos/test-com-server/releases/download/v1.0.0-alpha3/test-com-server-${env:DOWNLOADPLATFORM}.zip" 
+  - 7z e test-com-server-%DOWNLOADPLATFORM%.zip -oc:\gopath\src\github.com\go-ole\go-ole > NUL
+  - c:\gopath\src\github.com\go-ole\go-ole\build\register-assembly.bat
   # - set
   - go version
   - go env
-  - go get -v -t ./...
+  - c:\gopath\src\github.com\go-ole\go-ole\build\compile-go.bat
+  - go tool dist install -v cmd/8a
+  - go tool dist install -v cmd/8c
+  - go tool dist install -v cmd/8g
+  - go tool dist install -v cmd/8l
+  - go tool dist install -v cmd/6a
+  - go tool dist install -v cmd/6c
+  - go tool dist install -v cmd/6g
+  - go tool dist install -v cmd/6l
   - go get -u golang.org/x/tools/cmd/cover
-#  - go get -u golang.org/x/tools/cmd/vet
+  - go get -u golang.org/x/tools/cmd/godoc
+  - go get -u golang.org/x/tools/cmd/stringer
 
 build_script:
+  - cd c:\gopath\src\github.com\go-ole\go-ole
+  - go get -v -t ./...
   - go build
-  - go test -race ./...
   - go test -v -cover ./...
 
 # disable automatic tests

--- a/build/compile-go.bat
+++ b/build/compile-go.bat
@@ -1,0 +1,5 @@
+@ECHO OFF
+
+ECHO "BUILD GOLANG"
+cd "%GOROOT%\src"
+./make.bat --dist-tool

--- a/build/register-assembly.bat
+++ b/build/register-assembly.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+
+IF "x86" == "%DOWNLOADPLATFORM%" (
+	CALL c:\Windows\Microsoft.NET\Framework\v4.0.30319\RegAsm.exe /codebase /nologo c:\gopath\src\github.com\go-ole\go-ole\TestCOMServer.dll
+)
+IF "x64" == "%DOWNLOADPLATFORM%" (
+	CALL c:\Windows\Microsoft.NET\Framework64\v4.0.30319\RegAsm.exe /codebase /nologo c:\gopath\src\github.com\go-ole\go-ole\TestCOMServer.dll
+)


### PR DESCRIPTION
* Add compile-go.bat to build tools for x64 and x32 compilation.
* Add register-assembly.bat to register COM Server after downloading.
* Change build to better match version and branch for better tracking.
* Add 32-bit build to ensure 32-bit compilation works with 32-bit COM Server.
* Finish fast.
* Install MinGW and add to path manually.
* Download COM Test Server.
* Build 386 and amd64 compilers.
* Get GoDoc tool.
* Get Stringer tool.
* Change to cloned path.