### PR TITLE
Appveyor changes and inline documentation.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
-# Version 1.1.X
+# Version 1.2.0-alphaX
 
  * Add CI configuration for Travis-CI and AppVeyor.
  * Add test InterfaceID and ClassID for the COM Test Server project.
+ * Add more inline documentation.
  * **Add more test cases and reference new test COM server project.** (Placeholder for future additions)
 
 # Version 1.1.1

--- a/build/compile-go.bat
+++ b/build/compile-go.bat
@@ -1,5 +1,5 @@
-@ECHO OFF
+@echo OFF
 
-ECHO "BUILD GOLANG"
+echo "BUILD GOLANG"
 cd "%GOROOT%\src"
 ./make.bat --dist-tool

--- a/com.go
+++ b/com.go
@@ -35,6 +35,15 @@ var (
 	procDispatchMessageW, _ = moduser32.FindProc("DispatchMessageW")
 )
 
+// coInitialize initializes COM library on current thread.
+//
+// MSDN documentation suggests that this function should not be called. Call
+// CoInitializeEx() instead. The reason has to do with threading and this
+// function is only for single-threaded apartments.
+//
+// That said, most users of the library have gotten away with just this
+// function. If you are experiencing threading issues, then use
+// CoInitializeEx().
 func coInitialize() (err error) {
 	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms678543(v=vs.85).aspx
 	// Suggests that no value should be passed to CoInitialized.
@@ -46,6 +55,7 @@ func coInitialize() (err error) {
 	return
 }
 
+// coInitializeEx initializes COM library with concurrency model.
 func coInitializeEx(coinit uint32) (err error) {
 	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms695279(v=vs.85).aspx
 	// Suggests that the first parameter is not only optional but should always be NULL.
@@ -56,6 +66,15 @@ func coInitializeEx(coinit uint32) (err error) {
 	return
 }
 
+// CoInitialize initializes COM library on current thread.
+//
+// MSDN documentation suggests that this function should not be called. Call
+// CoInitializeEx() instead. The reason has to do with threading and this
+// function is only for single-threaded apartments.
+//
+// That said, most users of the library have gotten away with just this
+// function. If you are experiencing threading issues, then use
+// CoInitializeEx().
 func CoInitialize(p uintptr) (err error) {
 	// p is ignored and won't be used.
 	// Avoid any variable not used errors.
@@ -63,20 +82,36 @@ func CoInitialize(p uintptr) (err error) {
 	return coInitialize()
 }
 
+// CoInitializeEx initializes COM library with concurrency model.
 func CoInitializeEx(p uintptr, coinit uint32) (err error) {
 	// Avoid any variable not used errors.
 	p = uintptr(0)
 	return coInitializeEx(coinit)
 }
 
+// CoUninitialize uninitializes COM Library.
 func CoUninitialize() {
 	procCoUninitialize.Call()
 }
 
+// CoTaskMemFree frees memory pointer.
 func CoTaskMemFree(memptr uintptr) {
 	procCoTaskMemFree.Call(memptr)
 }
 
+// CLSIDFromProgID retrieves Class Identifier with the given Program Identifier.
+//
+// The Programmatic Identifier must be registered, because it will be looked up
+// in the Windows Registry. The registry entry has the following keys: CLSID,
+// Insertable, Protocol and Shell
+// (https://msdn.microsoft.com/en-us/library/dd542719(v=vs.85).aspx).
+//
+// programID identifies the class id with less precision and is not guaranteed
+// to be unique. These are usually found in the registry under
+// HKEY_LOCAL_MACHINE\SOFTWARE\Classes, usually with the format of
+// "Program.Component.Version" with version being optional.
+//
+// CLSIDFromProgID in Windows API.
 func CLSIDFromProgID(progId string) (clsid *GUID, err error) {
 	var guid GUID
 	lpszProgID := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(progId)))
@@ -88,6 +123,12 @@ func CLSIDFromProgID(progId string) (clsid *GUID, err error) {
 	return
 }
 
+// CLSIDFromString retrieves Class ID from string representation.
+//
+// This is technically the string version of the GUID and will convert the
+// string to object.
+//
+// CLSIDFromString in Windows API.
 func CLSIDFromString(str string) (clsid *GUID, err error) {
 	var guid GUID
 	lpsz := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(str)))
@@ -99,6 +140,7 @@ func CLSIDFromString(str string) (clsid *GUID, err error) {
 	return
 }
 
+// StringFromCLSID returns GUID formated string from GUID object.
 func StringFromCLSID(clsid *GUID) (str string, err error) {
 	var p *uint16
 	hr, _, _ := procStringFromCLSID.Call(uintptr(unsafe.Pointer(clsid)), uintptr(unsafe.Pointer(&p)))
@@ -109,6 +151,7 @@ func StringFromCLSID(clsid *GUID) (str string, err error) {
 	return
 }
 
+// IIDFromString returns GUID from program ID.
 func IIDFromString(progId string) (clsid *GUID, err error) {
 	var guid GUID
 	lpsz := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(progId)))
@@ -120,6 +163,7 @@ func IIDFromString(progId string) (clsid *GUID, err error) {
 	return
 }
 
+// StringFromIID returns GUID formatted string from GUID object.
 func StringFromIID(iid *GUID) (str string, err error) {
 	var p *uint16
 	hr, _, _ := procStringFromIID.Call(uintptr(unsafe.Pointer(iid)), uintptr(unsafe.Pointer(&p)))
@@ -130,6 +174,7 @@ func StringFromIID(iid *GUID) (str string, err error) {
 	return
 }
 
+// CreateInstance of single uninitialized object with GUID.
 func CreateInstance(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 	if iid == nil {
 		iid = IID_IUnknown
@@ -146,6 +191,7 @@ func CreateInstance(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 	return
 }
 
+// GetActiveObject retrieves pointer to active object.
 func GetActiveObject(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 	if iid == nil {
 		iid = IID_IUnknown
@@ -160,6 +206,7 @@ func GetActiveObject(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 	return
 }
 
+// VariantInit initializes variant.
 func VariantInit(v *VARIANT) (err error) {
 	hr, _, _ := procVariantInit.Call(uintptr(unsafe.Pointer(v)))
 	if hr != 0 {
@@ -168,6 +215,7 @@ func VariantInit(v *VARIANT) (err error) {
 	return
 }
 
+// VariantClear clears value in Variant settings to VT_EMPTY.
 func VariantClear(v *VARIANT) (err error) {
 	hr, _, _ := procVariantClear.Call(uintptr(unsafe.Pointer(v)))
 	if hr != 0 {
@@ -176,12 +224,14 @@ func VariantClear(v *VARIANT) (err error) {
 	return
 }
 
+// SysAllocString allocates memory for string and copies string into memory.
 func SysAllocString(v string) (ss *int16) {
 	pss, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(v))))
 	ss = (*int16)(unsafe.Pointer(pss))
 	return
 }
 
+// SysAllocStringLen copies up to length of given string returning pointer.
 func SysAllocStringLen(v string) (ss *int16) {
 	utf16 := utf16.Encode([]rune(v + "\x00"))
 	ptr := &utf16[0]
@@ -191,6 +241,7 @@ func SysAllocStringLen(v string) (ss *int16) {
 	return
 }
 
+// SysFreeString frees string system memory. This must be called with SysAllocString.
 func SysFreeString(v *int16) (err error) {
 	hr, _, _ := procSysFreeString.Call(uintptr(unsafe.Pointer(v)))
 	if hr != 0 {
@@ -199,11 +250,17 @@ func SysFreeString(v *int16) (err error) {
 	return
 }
 
+// SysStringLen is the length of the system allocated string.
 func SysStringLen(v *int16) uint32 {
 	l, _, _ := procSysStringLen.Call(uintptr(unsafe.Pointer(v)))
 	return uint32(l)
 }
 
+// CreateStdDispatch provides default IDispatch implementation for IUnknown.
+//
+// This handles default IDispatch implementation for objects. It haves a few
+// limitations with only supporting one language. It will also only return
+// default exception codes.
 func CreateStdDispatch(unk *IUnknown, v uintptr, ptinfo *IUnknown) (disp *IDispatch, err error) {
 	hr, _, _ := procCreateStdDispatch.Call(
 		uintptr(unsafe.Pointer(unk)),
@@ -216,6 +273,9 @@ func CreateStdDispatch(unk *IUnknown, v uintptr, ptinfo *IUnknown) (disp *IDispa
 	return
 }
 
+// CreateDispTypeInfo provides default ITypeInfo implementation for IDispatch.
+//
+// This will not handle the full implementation of the interface.
 func CreateDispTypeInfo(idata *INTERFACEDATA) (pptinfo *IUnknown, err error) {
 	hr, _, _ := procCreateDispTypeInfo.Call(
 		uintptr(unsafe.Pointer(idata)),
@@ -227,22 +287,28 @@ func CreateDispTypeInfo(idata *INTERFACEDATA) (pptinfo *IUnknown, err error) {
 	return
 }
 
+// copyMemory moves location of a block of memory.
 func copyMemory(dest unsafe.Pointer, src unsafe.Pointer, length uint32) {
 	procCopyMemory.Call(uintptr(dest), uintptr(src), uintptr(length))
 }
 
+// GetUserDefaultLCID retrieves current user default locale.
 func GetUserDefaultLCID() (lcid uint32) {
 	ret, _, _ := procGetUserDefaultLCID.Call()
 	lcid = uint32(ret)
 	return
 }
 
+// GetMessage in message queue from runtime.
+//
+// This function appears to block. PeekMessage does not block.
 func GetMessage(msg *Msg, hwnd uint32, MsgFilterMin uint32, MsgFilterMax uint32) (ret int32, err error) {
 	r0, _, err := procGetMessageW.Call(uintptr(unsafe.Pointer(msg)), uintptr(hwnd), uintptr(MsgFilterMin), uintptr(MsgFilterMax))
 	ret = int32(r0)
 	return
 }
 
+// DispatchMessage to window procedure.
 func DispatchMessage(msg *Msg) (ret int32) {
 	r0, _, _ := procDispatchMessageW.Call(uintptr(unsafe.Pointer(msg)))
 	ret = int32(r0)

--- a/com_func.go
+++ b/com_func.go
@@ -88,62 +88,80 @@ func StringFromIID(iid *GUID) (string, error) {
 	return "", NewError(E_NOTIMPL)
 }
 
+// CreateInstance of single uninitialized object with GUID.
 func CreateInstance(clsid *GUID, iid *GUID) (*IUnknown, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// GetActiveObject retrieves pointer to active object.
 func GetActiveObject(clsid *GUID, iid *GUID) (*IUnknown, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// VariantInit initializes variant.
 func VariantInit(v *VARIANT) error {
 	return NewError(E_NOTIMPL)
 }
 
+// VariantClear clears value in Variant settings to VT_EMPTY.
 func VariantClear(v *VARIANT) error {
 	return NewError(E_NOTIMPL)
 }
 
+// SysAllocString allocates memory for string and copies string into memory.
 func SysAllocString(v string) *int16 {
 	u := int16(0)
 	return &u
 }
 
+// SysAllocStringLen copies up to length of given string returning pointer.
 func SysAllocStringLen(v string) *int16 {
 	u := int16(0)
 	return &u
 }
 
+// SysFreeString frees string system memory. This must be called with SysAllocString.
 func SysFreeString(v *int16) error {
 	return NewError(E_NOTIMPL)
 }
 
+// SysStringLen is the length of the system allocated string.
 func SysStringLen(v *int16) uint32 {
 	return uint32(0)
 }
 
+// CreateStdDispatch provides default IDispatch implementation for IUnknown.
+//
+// This handles default IDispatch implementation for objects. It haves a few
+// limitations with only supporting one language. It will also only return
+// default exception codes.
 func CreateStdDispatch(unk *IUnknown, v uintptr, ptinfo *IUnknown) (*IDispatch, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// CreateDispTypeInfo provides default ITypeInfo implementation for IDispatch.
+//
+// This will not handle the full implementation of the interface.
 func CreateDispTypeInfo(idata *INTERFACEDATA) (*IUnknown, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// copyMemory moves location of a block of memory.
 func copyMemory(dest unsafe.Pointer, src unsafe.Pointer, length uint32) {}
 
-// GetUserDefaultLCID retrieves current user Locale ID for COM servers that are
-// localized.
+// GetUserDefaultLCID retrieves current user default locale.
 func GetUserDefaultLCID() uint32 {
 	return uint32(0)
 }
 
-// GetMessage from Runtime.
+// GetMessage in message queue from runtime.
+//
+// This function appears to block. PeekMessage does not block.
 func GetMessage(msg *Msg, hwnd uint32, MsgFilterMin uint32, MsgFilterMax uint32) (int32, error) {
 	return int32(0), NewError(E_NOTIMPL)
 }
 
-// DispatchMessage to Runtime.
+// DispatchMessage to window procedure.
 func DispatchMessage(msg *Msg) int32 {
 	return int32(0)
 }

--- a/com_func_test.go
+++ b/com_func_test.go
@@ -4,6 +4,7 @@ package ole
 
 import "testing"
 
+// TestComSetupAndShutDown tests that API fails on Linux.
 func TestComSetupAndShutDown(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -21,6 +22,7 @@ func TestComSetupAndShutDown(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestComPublicSetupAndShutDown tests that API fails on Linux.
 func TestComPublicSetupAndShutDown(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -38,6 +40,7 @@ func TestComPublicSetupAndShutDown(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestComPublicSetupAndShutDown_WithValue tests that API fails on Linux.
 func TestComPublicSetupAndShutDown_WithValue(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -55,6 +58,7 @@ func TestComPublicSetupAndShutDown_WithValue(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestComExSetupAndShutDown tests that API fails on Linux.
 func TestComExSetupAndShutDown(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -72,6 +76,7 @@ func TestComExSetupAndShutDown(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestComPublicExSetupAndShutDown tests that API fails on Linux.
 func TestComPublicExSetupAndShutDown(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -89,6 +94,7 @@ func TestComPublicExSetupAndShutDown(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestComPublicExSetupAndShutDown_WithValue tests that API fails on Linux.
 func TestComPublicExSetupAndShutDown_WithValue(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -106,6 +112,7 @@ func TestComPublicExSetupAndShutDown_WithValue(t *testing.T) {
 	CoUninitialize()
 }
 
+// TestClsidFromProgID_WindowsMediaNSSManager tests that API fails on Linux.
 func TestClsidFromProgID_WindowsMediaNSSManager(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -123,6 +130,7 @@ func TestClsidFromProgID_WindowsMediaNSSManager(t *testing.T) {
 	}
 }
 
+// TestClsidFromString_WindowsMediaNSSManager tests that API fails on Linux.
 func TestClsidFromString_WindowsMediaNSSManager(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -141,6 +149,7 @@ func TestClsidFromString_WindowsMediaNSSManager(t *testing.T) {
 	}
 }
 
+// TestCreateInstance_WindowsMediaNSSManager tests that API fails on Linux.
 func TestCreateInstance_WindowsMediaNSSManager(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -159,6 +168,7 @@ func TestCreateInstance_WindowsMediaNSSManager(t *testing.T) {
 	}
 }
 
+// TestError tests that API fails on Linux.
 func TestError(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/error_func.go
+++ b/error_func.go
@@ -2,6 +2,7 @@
 
 package ole
 
+// errstr converts error code to string.
 func errstr(errno int) string {
 	return ""
 }

--- a/error_windows.go
+++ b/error_windows.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf16"
 )
 
+// errstr converts error code to string.
 func errstr(errno int) string {
 	// ask windows for the remaining errors
 	var flags uint32 = syscall.FORMAT_MESSAGE_FROM_SYSTEM | syscall.FORMAT_MESSAGE_ARGUMENT_ARRAY | syscall.FORMAT_MESSAGE_IGNORE_INSERTS

--- a/go-get.go
+++ b/go-get.go
@@ -1,6 +1,0 @@
-// This file is here so go get succeeds, as without it errors with:
-// no buildable Go source files in ...
-//
-// +build !windows
-
-package ole

--- a/ole.go
+++ b/ole.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// DISPPARAMS are the arguments that passed to methods or property.
 type DISPPARAMS struct {
 	rgvarg            uintptr
 	rgdispidNamedArgs uintptr

--- a/safearray_func.go
+++ b/safearray_func.go
@@ -3,80 +3,135 @@
 package ole
 
 // safeArrayAccessData returns raw array pointer.
+//
+// AKA: SafeArrayAccessData in Windows API.
 func safeArrayAccessData(safearray *SafeArray) (uintptr, error) {
 	return uintptr(0), NewError(E_NOTIMPL)
 }
 
+// safeArrayUnaccessData releases raw array.
+//
+// AKA: SafeArrayUnaccessData in Windows API.
 func safeArrayUnaccessData(safearray *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayAllocData allocates SafeArray.
+//
+// AKA: SafeArrayAllocData in Windows API.
 func safeArrayAllocData(safearray *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayAllocDescriptor allocates SafeArray.
+//
+// AKA: SafeArrayAllocDescriptor in Windows API.
 func safeArrayAllocDescriptor(dimensions uint32) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayAllocDescriptorEx allocates SafeArray.
+//
+// AKA: SafeArrayAllocDescriptorEx in Windows API.
 func safeArrayAllocDescriptorEx(variantType VT, dimensions uint32) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayCopy returns copy of SafeArray.
+//
+// AKA: SafeArrayCopy in Windows API.
 func safeArrayCopy(original *SafeArray) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayCopyData duplicates SafeArray into another SafeArray object.
+//
+// AKA: SafeArrayCopyData in Windows API.
 func safeArrayCopyData(original *SafeArray, duplicate *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayCreate creates SafeArray.
+//
+// AKA: SafeArrayCreate in Windows API.
 func safeArrayCreate(variantType VT, dimensions uint32, bounds *SafeArrayBound) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayCreateEx creates SafeArray.
+//
+// AKA: SafeArrayCreateEx in Windows API.
 func safeArrayCreateEx(variantType VT, dimensions uint32, bounds *SafeArrayBound, extra uintptr) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayCreateVector creates SafeArray.
+//
+// AKA: SafeArrayCreateVector in Windows API.
 func safeArrayCreateVector(variantType VT, lowerBound int32, length uint32) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayCreateVectorEx creates SafeArray.
+//
+// AKA: SafeArrayCreateVectorEx in Windows API.
 func safeArrayCreateVectorEx(variantType VT, lowerBound int32, length uint32, extra uintptr) (*SafeArray, error) {
 	return nil, NewError(E_NOTIMPL)
 }
 
+// safeArrayDestroy destroys SafeArray object.
+//
+// AKA: SafeArrayDestroy in Windows API.
 func safeArrayDestroy(safearray *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayDestroyData destroys SafeArray object.
+//
+// AKA: SafeArrayDestroyData in Windows API.
 func safeArrayDestroyData(safearray *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayDestroyDescriptor destroys SafeArray object.
+//
+// AKA: SafeArrayDestroyDescriptor in Windows API.
 func safeArrayDestroyDescriptor(safearray *SafeArray) error {
 	return NewError(E_NOTIMPL)
 }
 
+// safeArrayGetDim is the amount of dimensions in the SafeArray.
+//
+// SafeArrays may have multiple dimensions. Meaning, it could be
+// multidimensional array.
+//
+// AKA: SafeArrayGetDim in Windows API.
 func safeArrayGetDim(safearray *SafeArray) (*uint32, error) {
 	u := uint32(0)
 	return &u, NewError(E_NOTIMPL)
 }
 
+// safeArrayGetElementSize is the element size in bytes.
+//
+// AKA: SafeArrayGetElemsize in Windows API.
 func safeArrayGetElementSize(safearray *SafeArray) (*uint32, error) {
 	u := uint32(0)
 	return &u, NewError(E_NOTIMPL)
 }
 
+// safeArrayGetElement retrieves element at given index.
 func safeArrayGetElement(safearray *SafeArray, index int64) (uintptr, error) {
 	return uintptr(0), NewError(E_NOTIMPL)
 }
 
+// safeArrayGetElement retrieves element at given index and converts to string.
 func safeArrayGetElementString(safearray *SafeArray, index int64) (string, error) {
 	return "", NewError(E_NOTIMPL)
 }
 
+// safeArrayGetIID is the InterfaceID of the elements in the SafeArray.
+//
+// AKA: SafeArrayGetIID in Windows API.
 func safeArrayGetIID(safearray *SafeArray) (*GUID, error) {
 	return nil, NewError(E_NOTIMPL)
 }

--- a/safearray_windows.go
+++ b/safearray_windows.go
@@ -38,7 +38,9 @@ var (
 	//procSafeArraySetRecordInfo, _     = modoleaut32.FindProc("SafeArraySetRecordInfo") // TODO
 )
 
-// Returns Raw Array
+// safeArrayAccessData returns raw array pointer.
+//
+// AKA: SafeArrayAccessData in Windows API.
 // Todo: Test
 func safeArrayAccessData(safearray *SafeArray) (element uintptr, err error) {
 	err = convertHresultToError(
@@ -48,22 +50,34 @@ func safeArrayAccessData(safearray *SafeArray) (element uintptr, err error) {
 	return
 }
 
+// safeArrayUnaccessData releases raw array.
+//
+// AKA: SafeArrayUnaccessData in Windows API.
 func safeArrayUnaccessData(safearray *SafeArray) (err error) {
 	err = convertHresultToError(procSafeArrayUnaccessData.Call(uintptr(unsafe.Pointer(safearray))))
 	return
 }
 
+// safeArrayAllocData allocates SafeArray.
+//
+// AKA: SafeArrayAllocData in Windows API.
 func safeArrayAllocData(safearray *SafeArray) (err error) {
 	err = convertHresultToError(procSafeArrayAllocData.Call(uintptr(unsafe.Pointer(safearray))))
 	return
 }
 
+// safeArrayAllocDescriptor allocates SafeArray.
+//
+// AKA: SafeArrayAllocDescriptor in Windows API.
 func safeArrayAllocDescriptor(dimensions uint32) (safearray *SafeArray, err error) {
 	err = convertHresultToError(
 		procSafeArrayAllocDescriptor.Call(uintptr(dimensions), uintptr(unsafe.Pointer(&safearray))))
 	return
 }
 
+// safeArrayAllocDescriptorEx allocates SafeArray.
+//
+// AKA: SafeArrayAllocDescriptorEx in Windows API.
 func safeArrayAllocDescriptorEx(variantType VT, dimensions uint32) (safearray *SafeArray, err error) {
 	err = convertHresultToError(
 		procSafeArrayAllocDescriptorEx.Call(
@@ -73,6 +87,9 @@ func safeArrayAllocDescriptorEx(variantType VT, dimensions uint32) (safearray *S
 	return
 }
 
+// safeArrayCopy returns copy of SafeArray.
+//
+// AKA: SafeArrayCopy in Windows API.
 func safeArrayCopy(original *SafeArray) (safearray *SafeArray, err error) {
 	err = convertHresultToError(
 		procSafeArrayCopy.Call(
@@ -81,6 +98,9 @@ func safeArrayCopy(original *SafeArray) (safearray *SafeArray, err error) {
 	return
 }
 
+// safeArrayCopyData duplicates SafeArray into another SafeArray object.
+//
+// AKA: SafeArrayCopyData in Windows API.
 func safeArrayCopyData(original *SafeArray, duplicate *SafeArray) (err error) {
 	err = convertHresultToError(
 		procSafeArrayCopyData.Call(
@@ -89,6 +109,9 @@ func safeArrayCopyData(original *SafeArray, duplicate *SafeArray) (err error) {
 	return
 }
 
+// safeArrayCreate creates SafeArray.
+//
+// AKA: SafeArrayCreate in Windows API.
 func safeArrayCreate(variantType VT, dimensions uint32, bounds *SafeArrayBound) (safearray *SafeArray, err error) {
 	sa, _, err := procSafeArrayCreate.Call(
 		uintptr(variantType),
@@ -98,6 +121,9 @@ func safeArrayCreate(variantType VT, dimensions uint32, bounds *SafeArrayBound) 
 	return
 }
 
+// safeArrayCreateEx creates SafeArray.
+//
+// AKA: SafeArrayCreateEx in Windows API.
 func safeArrayCreateEx(variantType VT, dimensions uint32, bounds *SafeArrayBound, extra uintptr) (safearray *SafeArray, err error) {
 	sa, _, err := procSafeArrayCreateEx.Call(
 		uintptr(variantType),
@@ -108,6 +134,9 @@ func safeArrayCreateEx(variantType VT, dimensions uint32, bounds *SafeArrayBound
 	return
 }
 
+// safeArrayCreateVector creates SafeArray.
+//
+// AKA: SafeArrayCreateVector in Windows API.
 func safeArrayCreateVector(variantType VT, lowerBound int32, length uint32) (safearray *SafeArray, err error) {
 	sa, _, err := procSafeArrayCreateVector.Call(
 		uintptr(variantType),
@@ -117,6 +146,9 @@ func safeArrayCreateVector(variantType VT, lowerBound int32, length uint32) (saf
 	return
 }
 
+// safeArrayCreateVectorEx creates SafeArray.
+//
+// AKA: SafeArrayCreateVectorEx in Windows API.
 func safeArrayCreateVectorEx(variantType VT, lowerBound int32, length uint32, extra uintptr) (safearray *SafeArray, err error) {
 	sa, _, err := procSafeArrayCreateVectorEx.Call(
 		uintptr(variantType),
@@ -127,33 +159,52 @@ func safeArrayCreateVectorEx(variantType VT, lowerBound int32, length uint32, ex
 	return
 }
 
+// safeArrayDestroy destroys SafeArray object.
+//
+// AKA: SafeArrayDestroy in Windows API.
 func safeArrayDestroy(safearray *SafeArray) (err error) {
 	err = convertHresultToError(procSafeArrayDestroy.Call(uintptr(unsafe.Pointer(safearray))))
 	return
 }
 
+// safeArrayDestroyData destroys SafeArray object.
+//
+// AKA: SafeArrayDestroyData in Windows API.
 func safeArrayDestroyData(safearray *SafeArray) (err error) {
 	err = convertHresultToError(procSafeArrayDestroyData.Call(uintptr(unsafe.Pointer(safearray))))
 	return
 }
 
+// safeArrayDestroyDescriptor destroys SafeArray object.
+//
+// AKA: SafeArrayDestroyDescriptor in Windows API.
 func safeArrayDestroyDescriptor(safearray *SafeArray) (err error) {
 	err = convertHresultToError(procSafeArrayDestroyDescriptor.Call(uintptr(unsafe.Pointer(safearray))))
 	return
 }
 
+// safeArrayGetDim is the amount of dimensions in the SafeArray.
+//
+// SafeArrays may have multiple dimensions. Meaning, it could be
+// multidimensional array.
+//
+// AKA: SafeArrayGetDim in Windows API.
 func safeArrayGetDim(safearray *SafeArray) (dimensions *uint32, err error) {
 	l, _, err := procSafeArrayGetDim.Call(uintptr(unsafe.Pointer(safearray)))
 	dimensions = (*uint32)(unsafe.Pointer(l))
 	return
 }
 
+// safeArrayGetElementSize is the element size in bytes.
+//
+// AKA: SafeArrayGetElemsize in Windows API.
 func safeArrayGetElementSize(safearray *SafeArray) (length *uint32, err error) {
 	l, _, err := procSafeArrayGetElemsize.Call(uintptr(unsafe.Pointer(safearray)))
 	length = (*uint32)(unsafe.Pointer(l))
 	return
 }
 
+// safeArrayGetElement retrieves element at given index.
 func safeArrayGetElement(safearray *SafeArray, index int64) (element uintptr, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetElement.Call(
@@ -163,6 +214,7 @@ func safeArrayGetElement(safearray *SafeArray, index int64) (element uintptr, er
 	return
 }
 
+// safeArrayGetElement retrieves element at given index and converts to string.
 func safeArrayGetElementString(safearray *SafeArray, index int64) (str string, err error) {
 	var element *int16
 	err = convertHresultToError(
@@ -175,6 +227,9 @@ func safeArrayGetElementString(safearray *SafeArray, index int64) (str string, e
 	return
 }
 
+// safeArrayGetIID is the InterfaceID of the elements in the SafeArray.
+//
+// AKA: SafeArrayGetIID in Windows API.
 func safeArrayGetIID(safearray *SafeArray) (guid *GUID, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetIID.Call(


### PR DESCRIPTION
* Use lowercase terms in batch file.
* Use 64-bit go and just set GOARCH for compilation. See if that works.
* Remove echoing path to reduce clutter.
* Use official project release instead of personal fork.
* Add comment about adding more inline documentation in change log.
* Inline documentation for COM functions.
* go-get.go file no longer needed since API supports building on Linux. Technically, cross compilation should still be supported, but hasn't been tested.
* Inline documentation for error string helper function.
* Inline documentation for structures and safearray functions.