### PR TITLE
Update safearray_windows.go

### DIFF
--- a/safearray_windows.go
+++ b/safearray_windows.go
@@ -333,6 +333,6 @@ func safeArraySetRecordInfo(safearray *SafeArray, recordInfo interface{}) (err e
 	err = convertHresultToError(
 		procSafeArraySetRecordInfo.Call(
 			uintptr(unsafe.Pointer(safearray)),
-			uintptr(unsafe.Pointer(recordInfo))))
+			uintptr(unsafe.Pointer(&recordInfo))))
 	return
 }


### PR DESCRIPTION
..\github.com\go-ole\go-ole\safearray_windows.go:336: cannot convert recordInfo (type interface {}) to type unsafe.Pointer: need type assertion
# github.com/mattn/go-ole