### PR TITLE
add []string{} variant

### DIFF
--- a/idispatch_windows.go
+++ b/idispatch_windows.go
@@ -138,6 +138,10 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 				safeByteArray := safeArrayFromByteSlice(v.([]byte))
 				vargs[n] = NewVariant(VT_ARRAY|VT_UI1, int64(uintptr(unsafe.Pointer(safeByteArray))))
 				defer VariantClear(&vargs[n])
+			case []string:
+				safeByteArray := safeArrayFromStringSlice(v.([]string))
+				vargs[n] = NewVariant(VT_ARRAY|VT_BSTR, int64(uintptr(unsafe.Pointer(safeByteArray))))
+				defer VariantClear(&vargs[n])
 			default:
 				panic("unknown type")
 			}

--- a/safearrayslices.go
+++ b/safearrayslices.go
@@ -2,7 +2,9 @@
 
 package ole
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 func safeArrayFromByteSlice(slice []byte) *SafeArray {
 	array, _ := safeArrayCreateVector(VT_UI1, 0, uint32(len(slice)))
@@ -13,6 +15,19 @@ func safeArrayFromByteSlice(slice []byte) *SafeArray {
 
 	for i, v := range slice {
 		safeArrayPutElement(array, int64(i), uintptr(unsafe.Pointer(&v)))
+	}
+	return array
+}
+
+func safeArrayFromStringSlice(slice []string) *SafeArray {
+	array, _ := safeArrayCreateVector(VT_BSTR, 0, uint32(len(slice)))
+
+	if array == nil {
+		panic("Could not convert []string to SAFEARRAY")
+	}
+	// SysAllocStringLen(s)
+	for i, v := range slice {
+		safeArrayPutElement(array, int64(i), uintptr(unsafe.Pointer(SysAllocStringLen(v))))
 	}
 	return array
 }


### PR DESCRIPTION
This PR adds the ability to pass string arrays to methods. An example is:

https://msdn.microsoft.com/en-us/library/hh850040%28v=vs.85%29.aspx

Crudely used here:

https://github.com/gabriel-samfira/go-wmi/blob/master/virt/network.go#L235

to create a Hyper-V VMSwitch.