### PR TITLE
Remove 32bit test.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,14 @@
 #   - All section names are case-sensitive.
 #   - Section names should be unique on each level.
 
-version: "1.2.0.{build}-alpha-{branch}"
+version: "1.3.0.{build}-alpha-{branch}"
 
 os: Windows Server 2012 R2
 
 branches:
   only:
     - master
+    - v1.2
     - v1.1
     - v1.0
 
@@ -25,18 +26,6 @@ environment:
     GOVERSION: 1.4
     GOROOT: c:\go
     DOWNLOADPLATFORM: "x64"
-  - GOARCH: 386
-    GOVERSION: 1.4
-    GOROOT: c:\go
-    DOWNLOADPLATFORM: "x86"
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - GOARCH: 386
-      GOVERSION: 1.4
-      GOROOT: c:\go
-      DOWNLOADPLATFORM: "x86"
 
 install:
   - choco install mingw


### PR DESCRIPTION
Windows CI will only test 64-bit execution. Testing 32-bit will have to be done manually. Please create ticket for problems.