### PR TITLE
Fix invoke in idispatch_windows.go with *string parameters

### DIFF
--- a/idispatch_windows.go
+++ b/idispatch_windows.go
@@ -180,17 +180,14 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 	if hr != 0 {
 		err = NewErrorWithSubError(hr, BstrToString(excepInfo.bstrDescription), excepInfo)
 	}
-	for _, varg := range vargs {
+	for i, varg := range vargs {
+		n := len(params) - i - 1
 		if varg.VT == VT_BSTR && varg.Val != 0 {
 			SysFreeString(((*int16)(unsafe.Pointer(uintptr(varg.Val)))))
 		}
-		/*
-			if varg.VT == (VT_BSTR|VT_BYREF) && varg.Val != 0 {
-				*(params[n].(*string)) = LpOleStrToString((*uint16)(unsafe.Pointer(uintptr(varg.Val))))
-				println(*(params[n].(*string)))
-				fmt.Fprintln(os.Stderr, *(params[n].(*string)))
-			}
-		*/
+		if varg.VT == (VT_BSTR|VT_BYREF) && varg.Val != 0 {
+			*(params[n].(*string)) = LpOleStrToString(*(**uint16)(unsafe.Pointer(uintptr(varg.Val))))
+		}
 	}
 	return
 }


### PR DESCRIPTION
This addresses issue #115. In that issue I also suggested renaming the LpOleStrToString function, but upon closer examination, the current nomenclature makes sense. I just wasn't that familiar with the windows data types and assumed LPSTR referred to a pointer to a string:```(**WCHAR)```, not the string itself ```(*WCHAR)```.

I did not create tests as I'm not familiar enough with the current testing setup. I have tested the change against a COM interface for an accounting system (Sage 100).