### PR TITLE
Add native GUID string parsing

### DIFF
--- a/guid.go
+++ b/guid.go
@@ -2,28 +2,28 @@ package ole
 
 var (
 	// IID_NULL is null Interface ID, used when no other Interface ID is known.
-	IID_NULL = &GUID{0x00000000, 0x0000, 0x0000, [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}
+	IID_NULL = NewGUID("{00000000-0000-0000-0000-000000000000}")
 
 	// IID_IUnknown is for IUnknown interfaces.
-	IID_IUnknown = &GUID{0x00000000, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}
+	IID_IUnknown = NewGUID("{00000000-0000-0000-C000-000000000046}")
 
 	// IID_IDispatch is for IDispatch interfaces.
-	IID_IDispatch = &GUID{0x00020400, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}
+	IID_IDispatch = NewGUID("{00020400-0000-0000-C000-000000000046}")
 
 	// IID_IEnumVariant is for IEnumVariant interfaces
-	IID_IEnumVariant = &GUID{0x00020404, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}
+	IID_IEnumVariant = NewGUID("{00020404-0000-0000-C000-000000000046}")
 
 	// IID_IConnectionPointContainer is for IConnectionPointContainer interfaces.
-	IID_IConnectionPointContainer = &GUID{0xB196B284, 0xBAB4, 0x101A, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}
+	IID_IConnectionPointContainer = NewGUID("{B196B284-BAB4-101A-B69C-00AA00341D07}")
 
 	// IID_IConnectionPoint is for IConnectionPoint interfaces.
-	IID_IConnectionPoint = &GUID{0xB196B286, 0xBAB4, 0x101A, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}
+	IID_IConnectionPoint = NewGUID("{B196B286-BAB4-101A-B69C-00AA00341D07}")
 
 	// IID_IInspectable is for IInspectable interfaces.
-	IID_IInspectable = &GUID{0xaf86e2e0, 0xb12d, 0x4c6a, [8]byte{0x9c, 0x5a, 0xd7, 0xaa, 0x65, 0x10, 0x1e, 0x90}}
+	IID_IInspectable = NewGUID("{AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90}")
 
 	// IID_IProvideClassInfo is for IProvideClassInfo interfaces.
-	IID_IProvideClassInfo = &GUID{0xb196b283, 0xbab4, 0x101a, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}
+	IID_IProvideClassInfo = NewGUID("{B196B283-BAB4-101A-B69C-00AA00341D07}")
 )
 
 // These are for testing and not part of any library.
@@ -31,63 +31,66 @@ var (
 	// IID_ICOMTestString is for ICOMTestString interfaces.
 	//
 	// {E0133EB4-C36F-469A-9D3D-C66B84BE19ED}
-	IID_ICOMTestString = &GUID{0xe0133eb4, 0xc36f, 0x469a, [8]byte{0x9d, 0x3d, 0xc6, 0x6b, 0x84, 0xbe, 0x19, 0xed}}
+	IID_ICOMTestString = NewGUID("{E0133EB4-C36F-469A-9D3D-C66B84BE19ED}")
 
 	// IID_ICOMTestInt8 is for ICOMTestInt8 interfaces.
 	//
-	// {BEB06610-EB84-4155-AF58-E2BFF53608B4}
-	IID_ICOMTestInt8 = &GUID{0xbeb06610, 0xeb84, 0x4155, [8]byte{0xaf, 0x58, 0xe2, 0xbf, 0xf5, 0x36, 0x80, 0xb4}}
+	// {BEB06610-EB84-4155-AF58-E2BFF53680B4}
+	IID_ICOMTestInt8 = NewGUID("{BEB06610-EB84-4155-AF58-E2BFF53680B4}")
 
 	// IID_ICOMTestInt16 is for ICOMTestInt16 interfaces.
 	//
 	// {DAA3F9FA-761E-4976-A860-8364CE55F6FC}
-	IID_ICOMTestInt16 = &GUID{0xdaa3f9fa, 0x761e, 0x4976, [8]byte{0xa8, 0x60, 0x83, 0x64, 0xce, 0x55, 0xf6, 0xfc}}
+	IID_ICOMTestInt16 = NewGUID("{DAA3F9FA-761E-4976-A860-8364CE55F6FC}")
 
 	// IID_ICOMTestInt32 is for ICOMTestInt32 interfaces.
 	//
 	// {E3DEDEE7-38A2-4540-91D1-2EEF1D8891B0}
-	IID_ICOMTestInt32 = &GUID{0xe3dedee7, 0x38a2, 0x4540, [8]byte{0x91, 0xd1, 0x2e, 0xef, 0x1d, 0x88, 0x91, 0xb0}}
+	IID_ICOMTestInt32 = NewGUID("{E3DEDEE7-38A2-4540-91D1-2EEF1D8891B0}")
 
 	// IID_ICOMTestInt64 is for ICOMTestInt64 interfaces.
 	//
 	// {8D437CBC-B3ED-485C-BC32-C336432A1623}
-	IID_ICOMTestInt64 = &GUID{0x8d437cbc, 0xb3ed, 0x485c, [8]byte{0xbc, 0x32, 0xc3, 0x36, 0x43, 0x2a, 0x16, 0x23}}
+	IID_ICOMTestInt64 = NewGUID("{8D437CBC-B3ED-485C-BC32-C336432A1623}")
 
 	// IID_ICOMTestFloat is for ICOMTestFloat interfaces.
 	//
 	// {BF1ED004-EA02-456A-AA55-2AC8AC6B054C}
-	IID_ICOMTestFloat = &GUID{0xbf1ed004, 0xea02, 0x456a, [8]byte{0xaa, 0x55, 0x2a, 0xc8, 0xac, 0x6b, 0x5, 0x4c}}
+	IID_ICOMTestFloat = NewGUID("{BF1ED004-EA02-456A-AA55-2AC8AC6B054C}")
 
 	// IID_ICOMTestDouble is for ICOMTestDouble interfaces.
 	//
 	// {BF908A81-8687-4E93-999F-D86FAB284BA0}
-	IID_ICOMTestDouble = &GUID{0xbf908a81, 0x8687, 0x4e93, [8]byte{0x99, 0x9f, 0xd8, 0x6f, 0xab, 0x28, 0x4b, 0xa0}}
+	IID_ICOMTestDouble = NewGUID("{BF908A81-8687-4E93-999F-D86FAB284BA0}")
 
 	// IID_ICOMTestBoolean is for ICOMTestBoolean interfaces.
 	//
-	// {D530E7A6-4EE8-40D1-8931-3D63B8605001}
-	IID_ICOMTestBoolean = &GUID{0xd530e7a6, 0x4ee8, 0x40d1, [8]byte{0x89, 0x31, 0x3d, 0x63, 0xb8, 0x60, 0x50, 0x10}}
+	// {D530E7A6-4EE8-40D1-8931-3D63B8605010}
+	IID_ICOMTestBoolean = NewGUID("{D530E7A6-4EE8-40D1-8931-3D63B8605010}")
 
 	// IID_ICOMEchoTestObject is for ICOMEchoTestObject interfaces.
 	//
 	// {6485B1EF-D780-4834-A4FE-1EBB51746CA3}
-	IID_ICOMEchoTestObject = &GUID{0x6485b1ef, 0xd780, 0x4834, [8]byte{0xa4, 0xfe, 0x1e, 0xbb, 0x51, 0x74, 0x6c, 0xa3}}
+	IID_ICOMEchoTestObject = NewGUID("{6485B1EF-D780-4834-A4FE-1EBB51746CA3}")
 
 	// IID_ICOMTestTypes is for ICOMTestTypes interfaces.
 	//
 	// {CCA8D7AE-91C0-4277-A8B3-FF4EDF28D3C0}
-	IID_ICOMTestTypes = &GUID{0xcca8d7ae, 0x91c0, 0x4277, [8]byte{0xa8, 0xb3, 0xff, 0x4e, 0xdf, 0x28, 0xd3, 0xc0}}
+	IID_ICOMTestTypes = NewGUID("{CCA8D7AE-91C0-4277-A8B3-FF4EDF28D3C0}")
 
 	// CLSID_COMEchoTestObject is for COMEchoTestObject class.
 	//
 	// {3C24506A-AE9E-4D50-9157-EF317281F1B0}
-	CLSID_COMEchoTestObject = &GUID{0x3c24506a, 0xae9e, 0x4d50, [8]byte{0x91, 0x57, 0xef, 0x31, 0x72, 0x81, 0xf1, 0xb0}}
+	CLSID_COMEchoTestObject = NewGUID("{3C24506A-AE9E-4D50-9157-EF317281F1B0}")
 
 	// CLSID_COMTestScalarClass is for COMTestScalarClass class.
 	//
 	// {865B85C5-0334-4AC6-9EF6-AACEC8FC5E86}
-	CLSID_COMTestScalarClass = &GUID{0x865b85c5, 0x0334, 0x4ac6, [8]byte{0x9e, 0xf6, 0xaa, 0xce, 0xc8, 0xfc, 0x5e, 0x86}}
+	CLSID_COMTestScalarClass = NewGUID("{865B85C5-0334-4AC6-9EF6-AACEC8FC5E86}")
 )
+
+const hextable = "0123456789ABCDEF"
+const emptyGUID = "{00000000-0000-0000-0000-000000000000}"
 
 // GUID is Windows API specific GUID type.
 //
@@ -98,6 +101,169 @@ type GUID struct {
 	Data2 uint16
 	Data3 uint16
 	Data4 [8]byte
+}
+
+// NewGUID converts the given string into a globally unique identifier that is
+// compliant with the Windows API.
+//
+// The supplied string may be in any of these formats:
+//
+//  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+//  XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+//  {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
+//
+// The conversion of the supplied string is not case-sensitive.
+func NewGUID(guid string) *GUID {
+	d := []byte(guid)
+	var d1, d2, d3, d4a, d4b []byte
+
+	switch len(d) {
+	case 38:
+		if d[0] != '{' || d[37] != '}' {
+			return nil
+		}
+		d = d[1:37]
+		fallthrough
+	case 36:
+		if d[8] != '-' || d[13] != '-' || d[18] != '-' || d[23] != '-' {
+			return nil
+		}
+		d1 = d[0:8]
+		d2 = d[9:13]
+		d3 = d[14:18]
+		d4a = d[19:23]
+		d4b = d[24:36]
+	case 32:
+		d1 = d[0:8]
+		d2 = d[8:12]
+		d3 = d[12:16]
+		d4a = d[16:20]
+		d4b = d[20:32]
+	default:
+		return nil
+	}
+
+	var g GUID
+	var ok1, ok2, ok3, ok4 bool
+	g.Data1, ok1 = decodeHexUint32(d1)
+	g.Data2, ok2 = decodeHexUint16(d2)
+	g.Data3, ok3 = decodeHexUint16(d3)
+	g.Data4, ok4 = decodeHexByte64(d4a, d4b)
+	if ok1 && ok2 && ok3 && ok4 {
+		return &g
+	}
+	return nil
+}
+
+func decodeHexUint32(src []byte) (value uint32, ok bool) {
+	var b1, b2, b3, b4 byte
+	var ok1, ok2, ok3, ok4 bool
+	b1, ok1 = decodeHexByte(src[0], src[1])
+	b2, ok2 = decodeHexByte(src[2], src[3])
+	b3, ok3 = decodeHexByte(src[4], src[5])
+	b4, ok4 = decodeHexByte(src[6], src[7])
+	value = (uint32(b1) << 24) | (uint32(b2) << 16) | (uint32(b3) << 8) | uint32(b4)
+	ok = ok1 && ok2 && ok3 && ok4
+	return
+}
+
+func decodeHexUint16(src []byte) (value uint16, ok bool) {
+	var b1, b2 byte
+	var ok1, ok2 bool
+	b1, ok1 = decodeHexByte(src[0], src[1])
+	b2, ok2 = decodeHexByte(src[2], src[3])
+	value = (uint16(b1) << 8) | uint16(b2)
+	ok = ok1 && ok2
+	return
+}
+
+func decodeHexByte64(s1 []byte, s2 []byte) (value [8]byte, ok bool) {
+	var ok1, ok2, ok3, ok4, ok5, ok6, ok7, ok8 bool
+	value[0], ok1 = decodeHexByte(s1[0], s1[1])
+	value[1], ok2 = decodeHexByte(s1[2], s1[3])
+	value[2], ok3 = decodeHexByte(s2[0], s2[1])
+	value[3], ok4 = decodeHexByte(s2[2], s2[3])
+	value[4], ok5 = decodeHexByte(s2[4], s2[5])
+	value[5], ok6 = decodeHexByte(s2[6], s2[7])
+	value[6], ok7 = decodeHexByte(s2[8], s2[9])
+	value[7], ok8 = decodeHexByte(s2[10], s2[11])
+	ok = ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8
+	return
+}
+
+func decodeHexByte(c1, c2 byte) (value byte, ok bool) {
+	var n1, n2 byte
+	var ok1, ok2 bool
+	n1, ok1 = decodeHexChar(c1)
+	n2, ok2 = decodeHexChar(c2)
+	value = (n1 << 4) | n2
+	ok = ok1 && ok2
+	return
+}
+
+func decodeHexChar(c byte) (byte, bool) {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, true
+	}
+
+	return 0, false
+}
+
+// String converts the GUID to string form. It will adhere to this pattern:
+//
+//  {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
+//
+// If the GUID is nil, the string representation of an empty GUID is returned:
+//
+//  {00000000-0000-0000-0000-000000000000}
+func (guid *GUID) String() string {
+	if guid == nil {
+		return emptyGUID
+	}
+
+	var c [38]byte
+	c[0] = '{'
+	putUint32Hex(c[1:9], guid.Data1)
+	c[9] = '-'
+	putUint16Hex(c[10:14], guid.Data2)
+	c[14] = '-'
+	putUint16Hex(c[15:19], guid.Data3)
+	c[19] = '-'
+	putByteHex(c[20:24], guid.Data4[0:2])
+	c[24] = '-'
+	putByteHex(c[25:37], guid.Data4[2:8])
+	c[37] = '}'
+	return string(c[:])
+}
+
+func putUint32Hex(b []byte, v uint32) {
+	b[0] = hextable[byte(v>>24)>>4]
+	b[1] = hextable[byte(v>>24)&0x0f]
+	b[2] = hextable[byte(v>>16)>>4]
+	b[3] = hextable[byte(v>>16)&0x0f]
+	b[4] = hextable[byte(v>>8)>>4]
+	b[5] = hextable[byte(v>>8)&0x0f]
+	b[6] = hextable[byte(v)>>4]
+	b[7] = hextable[byte(v)&0x0f]
+}
+
+func putUint16Hex(b []byte, v uint16) {
+	b[0] = hextable[byte(v>>8)>>4]
+	b[1] = hextable[byte(v>>8)&0x0f]
+	b[2] = hextable[byte(v)>>4]
+	b[3] = hextable[byte(v)&0x0f]
+}
+
+func putByteHex(dst, src []byte) {
+	for i := 0; i < len(src); i++ {
+		dst[i*2] = hextable[src[i]>>4]
+		dst[i*2+1] = hextable[src[i]&0x0f]
+	}
 }
 
 // IsEqualGUID compares two GUID.

--- a/guid_test.go
+++ b/guid_test.go
@@ -1,0 +1,80 @@
+package ole
+
+import (
+	"strings"
+	"testing"
+)
+
+var guidFixtures = []struct {
+	Name        string
+	S           string
+	G           *GUID
+	ShouldMatch bool
+}{
+	{"NULL", "{00000000-0000-0000-0000-000000000000}", &GUID{0x00000000, 0x0000, 0x0000, [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, true},
+	{"IUnknown", "{00000000-0000-0000-C000-000000000046}", &GUID{0x00000000, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}, true},
+	{"IDispatch", "{00020400-0000-0000-C000-000000000046}", &GUID{0x00020400, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}, true},
+	{"IEnumVariant", "{00020404-0000-0000-C000-000000000046}", &GUID{0x00020404, 0x0000, 0x0000, [8]byte{0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}, true},
+	{"IConnectionPointContainer", "{B196B284-BAB4-101A-B69C-00AA00341D07}", &GUID{0xB196B284, 0xBAB4, 0x101A, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}, true},
+	{"IConnectionPoint", "{B196B286-BAB4-101A-B69C-00AA00341D07}", &GUID{0xB196B286, 0xBAB4, 0x101A, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}, true},
+	{"IInspectable", "{AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90}", &GUID{0xaf86e2e0, 0xb12d, 0x4c6a, [8]byte{0x9c, 0x5a, 0xd7, 0xaa, 0x65, 0x10, 0x1e, 0x90}}, true},
+	{"IProvideClassInfo", "{B196B283-BAB4-101A-B69C-00AA00341D07}", &GUID{0xb196b283, 0xbab4, 0x101a, [8]byte{0xB6, 0x9C, 0x00, 0xAA, 0x00, 0x34, 0x1D, 0x07}}, true},
+	{"ICOMTestInt64", "{8D437CBC-B3ED-485C-BC32-C336432A1623}", &GUID{0x8d437cbc, 0xb3ed, 0x485c, [8]byte{0xbc, 0x32, 0xc3, 0x36, 0x43, 0x2a, 0x16, 0x23}}, true},
+	{"Pattern1", "{10000000-1000-1000-1000-100000000000}", &GUID{0x10000000, 0x1000, 0x1000, [8]byte{0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00}}, true},
+	{"Pattern2", "{01000000-0100-0100-0100-010000000000}", &GUID{0x01000000, 0x0100, 0x0100, [8]byte{0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}}, true},
+	{"Pattern3", "{00100000-0010-0010-0010-001000000000}", &GUID{0x00100000, 0x0010, 0x0010, [8]byte{0x00, 0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00}}, true},
+	{"Pattern4", "{00010000-0001-0001-0001-000100000000}", &GUID{0x00010000, 0x0001, 0x0001, [8]byte{0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}}, true},
+	{"Pattern5", "{a000a000-a000-a000-a000-a000a000a000}", &GUID{0xa000a000, 0xa000, 0xa000, [8]byte{0xa0, 0x00, 0xa0, 0x00, 0xa0, 0x00, 0xa0, 0x00}}, true},
+	{"Pattern6", "{0aaa0aaa-0aaa-0aaa-0aaa-0aaa0aaa0aaa}", &GUID{0x0aaa0aaa, 0x0aaa, 0x0aaa, [8]byte{0x0a, 0xaa, 0x0a, 0xaa, 0x0a, 0xaa, 0x0a, 0xaa}}, true},
+	{"Sequence1", "{12345678-1234-1234-1234-123456789abc}", &GUID{0x12345678, 0x1234, 0x1234, [8]byte{0x12, 0x34, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc}}, true},
+	{"Sequence2", "12345678-1234-1234-1234-123456789abc", &GUID{0x12345678, 0x1234, 0x1234, [8]byte{0x12, 0x34, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc}}, false},
+	{"Sequence3", "12345678123412341234123456789abc", &GUID{0x12345678, 0x1234, 0x1234, [8]byte{0x12, 0x34, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc}}, false},
+	{"CaseUpper1", "{ABCDEFAB-ABCD-ABCD-ABCD-ABCDEFABCDEF}", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, true},
+	{"CaseUpper2", "ABCDEFAB-ABCD-ABCD-ABCD-ABCDEFABCDEF", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, false},
+	{"CaseUpper3", "ABCDEFABABCDABCDABCDABCDEFABCDEF", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, false},
+	{"CaseLower1", "{abcdefab-abcd-abcd-abcd-abcdefabcdef}", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, true},
+	{"CaseLower2", "abcdefab-abcd-abcd-abcd-abcdefabcdef", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, false},
+	{"CaseLower3", "abcdefababcdabcdabcdabcdefabcdef", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, false},
+	{"CaseMixed1", "{AbCdEfAb-AbCd-AbCd-AbCd-AbCdEfAbCdEf}", &GUID{0xabcdefab, 0xabcd, 0xabcd, [8]byte{0xab, 0xcd, 0xab, 0xcd, 0xef, 0xab, 0xcd, 0xef}}, true},
+	{"CaseMixed2", "{fEdCbAfE-fEdC-fEdC-fEdC-fEdCbAfEdCbA}", &GUID{0xfedcbafe, 0xfedc, 0xfedc, [8]byte{0xfe, 0xdc, 0xfe, 0xdc, 0xba, 0xfe, 0xdc, 0xba}}, true},
+	{"Empty", "", nil, false},
+	{"EmptyBrackets", "{}", nil, false},
+	{"GarbageDash1", "----", nil, false},
+	{"GarbageDash2", "------------------------------------", nil, false},
+	{"GarbageDash3", "{------------------------------------}", nil, false},
+	{"GarbagePadding1", " {abcdefab-abcd-abcd-abcd-abcdefabcdef}", nil, false},
+	{"GarbagePadding2", "{abcdefab-abcd-abcd-abcd-abcdefabcdef} ", nil, false},
+	{"GarbagePadding3", " abcdefab-abcd-abcd-abcd-abcdefabcdef", nil, false},
+	{"GarbagePadding4", "abcdefab-abcd-abcd-abcd-abcdefabcdef ", nil, false},
+	{"GarbagePadding5", " abcdefababcdabcdabcdabcdefabcdef", nil, false},
+	{"GarbagePadding6", "abcdefababcdabcdabcdabcdefabcdef ", nil, false},
+	{"Garbage1", "AFR*@)#$BNHRO*IABNFVaaa", nil, false},
+	{"Garbage2", "#@*%@#&^%382765*@^#*&^%R*@&#%R7632", nil, false},
+	{"Garbage3", "#@*%@#&^%382765*@^#*&^%R*@&#%R76377^2", nil, false},
+	{"Garbage4", "{ABCDEFA*-ABCD-ABCD-ABCD-ABCDEFABCDEF}", nil, false},
+	{"Garbage5", "{gggggggg-ABCD-ABCD-ABCD-ABCDEFABCDEF}", nil, false},
+}
+
+// TestGUID tests both NewGUID and GUID.String.
+func TestGUID(t *testing.T) {
+	for i := 0; i < len(guidFixtures); i++ {
+		guid := NewGUID(guidFixtures[i].S)
+		f := guidFixtures[i]
+		if guid == nil {
+			if f.G != nil {
+				t.Errorf("GUID test \"%v\" (%v of %v) failed. Expected %v from NewGUID. Received <nil> instead.", f.Name, i, len(guidFixtures), f.G)
+			}
+		} else if f.G == nil {
+			t.Errorf("GUID test \"%v\" (%v of %v) failed. Expected <nil> from NewGUID. Received %v instead.", f.Name, i, len(guidFixtures), guid)
+		}
+		if guid == nil || f.G == nil {
+			continue
+		}
+		if !IsEqualGUID(guid, f.G) {
+			t.Errorf("GUID test \"%v\" (%v of %v) failed. Expected %v from NewGUID. Received %v instead.", f.Name, i, len(guidFixtures), f.G, guid)
+		}
+		if f.ShouldMatch && guid.String() != strings.ToUpper(f.S) {
+			t.Errorf("GUID test \"%v\" (%v of %v) failed. Expected \"%v\" from GUID.String. Received \"%v\" instead.", f.Name, i, len(guidFixtures), strings.ToUpper(f.S), guid)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds two new functions:

* A `NewGUID()` function that converts a string into a `GUID`. It's native Go and can be used in global variable declarations without initializing COM.
* A `String()` function for the `GUID` type that meets the `fmt.Stringer` interface definition. This allows `GUID` types to be printed nicely by the `fmt` package.

This PR also makes use of `NewGUID` for declaration of all of the well-known interface and class IDs.

The documented values of `IID_ICOMTestInt8` and `IID_ICOMTestBoolean ` did not match their actual values. The documentation has been updated to correct this.