### PR TITLE
add missing Release() calls in ienumvariant_test.go example

### DIFF
--- a/ienumvariant_test.go
+++ b/ienumvariant_test.go
@@ -62,6 +62,7 @@ func TestIEnumVariant_wmi(t *testing.T) {
 		t.Error("Enum is nil")
 		t.FailNow()
 	}
+	defer enum.Release()
 
 	for tmp, length, err := enum.Next(1); length > 0; tmp, length, err = enum.Next(1) {
 		if err != nil {
@@ -82,10 +83,11 @@ func TestIEnumVariant_wmi(t *testing.T) {
 		}
 		defer props_enum_property.Clear()
 
-		_, err = props_enum_property.ToIUnknown().IEnumVARIANT(IID_IEnumVariant)
+		props_enum, err := props_enum_property.ToIUnknown().IEnumVARIANT(IID_IEnumVariant)
 		if err != nil {
 			t.Errorf("IEnumVARIANT failed with %v", err)
 		}
+		defer props_enum.Release()
 
 		class_variant, err := tmp_dispatch.GetProperty("Name")
 		if err != nil {


### PR DESCRIPTION
The test example for using IEnumVARIANT is missing release calls for the enumerators, which causes a memory leak. We had [a PR to the wmi package](https://github.com/StackExchange/wmi/pull/14#issuecomment-236031901) that used the example code and it took a while to track down the cause so I figured I'd send a PR to fix the example.

