### PR TITLE
Add a missing return to the ConnectObject function

### DIFF
--- a/oleutil/connection_windows.go
+++ b/oleutil/connection_windows.go
@@ -49,6 +49,7 @@ func ConnectObject(disp *ole.IDispatch, iid *ole.GUID, idisp interface{}) (cooki
 			point.Release()
 			return
 		}
+		return
 	}
 
 	container.Release()


### PR DESCRIPTION
Without the return added by this commit the ConnectObject will return
E_INVALIDARG even if everything went fine.