### PR TITLE
Fix converting COM Variant Time value to Go time.Time

### DIFF
--- a/com.go
+++ b/com.go
@@ -321,9 +321,9 @@ func DispatchMessage(msg *Msg) (ret int32) {
 // GetVariantDate converts COM Variant Time value to Go time.Time.
 func GetVariantDate(value float64) (time.Time, error) {
 	var st syscall.Systemtime
-	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(unsafe.Pointer(&value)), uintptr(unsafe.Pointer(&st)))
+	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(value), uintptr(unsafe.Pointer(&st)))
 	if r != 0 {
-		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), nil), nil
+		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
 	}
 	return time.Now(), errors.New("Could not convert to time, passing current time.")
 }


### PR DESCRIPTION
This PR tries to fix the following issues:

### Missing *Location
Right now function `GetVariantDate` panics because `*Location` argument is missing in `time.Date` call:
```
panic: time: missing Location in call to Date
```
_Fix_:
`time.UTC` location was specified instead of the `nil`.

### Wrong data type passed to VariantTimeToSystemTime syscall
Function call 
```
procVariantTimeToSystemTime.Call(uintptr(unsafe.Pointer(&value)), uintptr(unsafe.Pointer(&st)))
```
 always returns struct with a static date `1899-12-30 00:00:00 +0000 UTC`

_Fix_:
According to [msdn](https://msdn.microsoft.com/en-us/library/ms891677.aspx?f=255&MSPPError=-2147217396) `VariantTimeToSystemTime` accepts first argument as a `double vtime` not a pointer to `vdata`, so `uintptr(unsafe.Pointer(&value))` was replaced with `uintptr(value)`.

Cheers
