### PR TITLE
Update AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
   GOPATH: c:\gopath
   matrix:
   - GOARCH: amd64
-    GOVERSION: 1.4
+    GOVERSION: 1.5
     GOROOT: c:\go
     DOWNLOADPLATFORM: "x64"
 
@@ -37,15 +37,6 @@ install:
   # - set
   - go version
   - go env
-  - c:\gopath\src\github.com\go-ole\go-ole\build\compile-go.bat
-  - go tool dist install -v cmd/8a
-  - go tool dist install -v cmd/8c
-  - go tool dist install -v cmd/8g
-  - go tool dist install -v cmd/8l
-  - go tool dist install -v cmd/6a
-  - go tool dist install -v cmd/6c
-  - go tool dist install -v cmd/6g
-  - go tool dist install -v cmd/6l
   - go get -u golang.org/x/tools/cmd/cover
   - go get -u golang.org/x/tools/cmd/godoc
   - go get -u golang.org/x/tools/cmd/stringer

--- a/build/compile-go.bat
+++ b/build/compile-go.bat
@@ -1,5 +1,0 @@
-@echo OFF
-
-echo "BUILD GOLANG"
-cd "%GOROOT%\src"
-./make.bat --dist-tool


### PR DESCRIPTION
This PR introduces minimum Go version to 1.5. Probably related to #113. 

Not sure why we still need the whole go-compiles-go stuff, so I decided to remove it. If it is undesirable just ping me. 

The project should be able to use existing amazing integration tests here.

The go-ole seems actually passes all of them right now.

