### PR TITLE
handle 32bit environment

### DIFF
--- a/com.go
+++ b/com.go
@@ -3,9 +3,7 @@
 package ole
 
 import (
-	"errors"
 	"syscall"
-	"time"
 	"unicode/utf16"
 	"unsafe"
 )
@@ -316,14 +314,4 @@ func DispatchMessage(msg *Msg) (ret int32) {
 	r0, _, _ := procDispatchMessageW.Call(uintptr(unsafe.Pointer(msg)))
 	ret = int32(r0)
 	return
-}
-
-// GetVariantDate converts COM Variant Time value to Go time.Time.
-func GetVariantDate(value float64) (time.Time, error) {
-	var st syscall.Systemtime
-	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(value), uintptr(unsafe.Pointer(&st)))
-	if r != 0 {
-		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
-	}
-	return time.Now(), errors.New("Could not convert to time, passing current time.")
 }

--- a/variant.go
+++ b/variant.go
@@ -88,10 +88,10 @@ func (v *VARIANT) Value() interface{} {
 		return v.ToString()
 	case VT_DATE:
 		// VT_DATE type will either return float64 or time.Time.
-		d := float64(v.Val)
+		d := uint64(v.Val)
 		date, err := GetVariantDate(d)
 		if err != nil {
-			return d
+			return float64(v.Val)
 		}
 		return date
 	case VT_UNKNOWN:

--- a/variant_386.go
+++ b/variant_386.go
@@ -2,10 +2,29 @@
 
 package ole
 
+import (
+	"errors"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
 type VARIANT struct {
 	VT         VT     //  2
 	wReserved1 uint16 //  4
 	wReserved2 uint16 //  6
 	wReserved3 uint16 //  8
 	Val        int64  // 16
+}
+
+// GetVariantDate converts COM Variant Time value to Go time.Time.
+func GetVariantDate(value uint64) (time.Time, error) {
+	var st syscall.Systemtime
+	v1 := uint32(value)
+	v2 := uint32(value >> 32)
+	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(v1), uintptr(v2), uintptr(unsafe.Pointer(&st)))
+	if r != 0 {
+		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
+	}
+	return time.Now(), errors.New("Could not convert to time, passing current time.")
 }

--- a/variant_amd64.go
+++ b/variant_amd64.go
@@ -2,6 +2,13 @@
 
 package ole
 
+import (
+	"errors"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
 type VARIANT struct {
 	VT         VT      //  2
 	wReserved1 uint16  //  4
@@ -9,4 +16,14 @@ type VARIANT struct {
 	wReserved3 uint16  //  8
 	Val        int64   // 16
 	_          [8]byte // 24
+}
+
+// GetVariantDate converts COM Variant Time value to Go time.Time.
+func GetVariantDate(value uint64) (time.Time, error) {
+	var st syscall.Systemtime
+	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(value), uintptr(unsafe.Pointer(&st)))
+	if r != 0 {
+		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
+	}
+	return time.Now(), errors.New("Could not convert to time, passing current time.")
 }


### PR DESCRIPTION
Under 386, a 64bit value needs to be passed as two 32bit values.