### PR TITLE
Fix README.md header formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Go OLE
+# Go OLE
 
 [![Build status](https://ci.appveyor.com/api/projects/status/qr0u2sf7q43us9fj?svg=true)](https://ci.appveyor.com/project/jacobsantos/go-ole-jgs28)
 [![Build Status](https://travis-ci.org/go-ole/go-ole.svg?branch=master)](https://travis-ci.org/go-ole/go-ole)
@@ -35,12 +35,12 @@ AppVeyor is used to build on Windows using the (in-development) test COM server.
 
 The tests currently do run and do pass and this should be maintained with commits.
 
-##Versioning
+## Versioning
 
 Go OLE uses [semantic versioning](http://semver.org) for version numbers, which is similar to the version contract of the Go language. Which means that the major version will always maintain backwards compatibility with minor versions. Minor versions will only add new additions and changes. Fixes will always be in patch. 
 
 This contract should allow you to upgrade to new minor and patch versions without breakage or modifications to your existing code. Leave a ticket, if there is breakage, so that it could be fixed.
 
-##LICENSE
+## LICENSE
 
 Under the MIT License: http://mattn.mit-license.org/2013


### PR DESCRIPTION
Hi - just adds a space to ensure GitHub renders headers as intended.