### PR TITLE
Fix for  #172

### DIFF
--- a/safearray_func.go
+++ b/safearray_func.go
@@ -124,12 +124,12 @@ func safeArrayGetElementSize(safearray *SafeArray) (*uint32, error) {
 }
 
 // safeArrayGetElement retrieves element at given index.
-func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) error {
+func safeArrayGetElement(safearray *SafeArray, index int32, pv unsafe.Pointer) error {
 	return NewError(E_NOTIMPL)
 }
 
 // safeArrayGetElement retrieves element at given index and converts to string.
-func safeArrayGetElementString(safearray *SafeArray, index int64) (string, error) {
+func safeArrayGetElementString(safearray *SafeArray, index int32) (string, error) {
 	return "", NewError(E_NOTIMPL)
 }
 
@@ -146,8 +146,8 @@ func safeArrayGetIID(safearray *SafeArray) (*GUID, error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetLBound in Windows API.
-func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int64, error) {
-	return int64(0), NewError(E_NOTIMPL)
+func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int32, error) {
+	return int32(0), NewError(E_NOTIMPL)
 }
 
 // safeArrayGetUBound returns upper bounds of SafeArray.
@@ -156,8 +156,8 @@ func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int64, error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetUBound in Windows API.
-func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (int64, error) {
-	return int64(0), NewError(E_NOTIMPL)
+func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (int32, error) {
+	return int32(0), NewError(E_NOTIMPL)
 }
 
 // safeArrayGetVartype returns data type of SafeArray.

--- a/safearray_test.go
+++ b/safearray_test.go
@@ -64,8 +64,8 @@ func Example_safeArrayGetElementString() {
 	qbXMLVersions = result.ToArray().Array
 
 	// Get array bounds
-	var LowerBounds int64
-	var UpperBounds int64
+	var LowerBounds int32
+	var UpperBounds int32
 	LowerBounds, err = safeArrayGetLBound(qbXMLVersions, 1)
 	if err != nil {
 		return
@@ -79,8 +79,8 @@ func Example_safeArrayGetElementString() {
 	totalElements := UpperBounds - LowerBounds + 1
 	qbXmlVersionStrings = make([]string, totalElements)
 
-	for i := int64(0); i < totalElements; i++ {
-		qbXmlVersionStrings[int32(i)], _ = safeArrayGetElementString(qbXMLVersions, i)
+	for i := int32(0); i < totalElements; i++ {
+		qbXmlVersionStrings[i], _ = safeArrayGetElementString(qbXMLVersions, i)
 	}
 
 	// Release Safe Array memory

--- a/safearray_windows.go
+++ b/safearray_windows.go
@@ -205,7 +205,7 @@ func safeArrayGetElementSize(safearray *SafeArray) (length *uint32, err error) {
 }
 
 // safeArrayGetElement retrieves element at given index.
-func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) error {
+func safeArrayGetElement(safearray *SafeArray, index int32, pv unsafe.Pointer) error {
 	return convertHresultToError(
 		procSafeArrayGetElement.Call(
 			uintptr(unsafe.Pointer(safearray)),
@@ -214,7 +214,7 @@ func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) e
 }
 
 // safeArrayGetElementString retrieves element at given index and converts to string.
-func safeArrayGetElementString(safearray *SafeArray, index int64) (str string, err error) {
+func safeArrayGetElementString(safearray *SafeArray, index int32) (str string, err error) {
 	var element *int16
 	err = convertHresultToError(
 		procSafeArrayGetElement.Call(
@@ -243,7 +243,7 @@ func safeArrayGetIID(safearray *SafeArray) (guid *GUID, err error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetLBound in Windows API.
-func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int64, err error) {
+func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int32, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetLBound.Call(
 			uintptr(unsafe.Pointer(safearray)),
@@ -258,7 +258,7 @@ func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int6
 // multidimensional array.
 //
 // AKA: SafeArrayGetUBound in Windows API.
-func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (upperBound int64, err error) {
+func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (upperBound int32, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetUBound.Call(
 			uintptr(unsafe.Pointer(safearray)),

--- a/safearrayconversion.go
+++ b/safearrayconversion.go
@@ -14,7 +14,7 @@ func (sac *SafeArrayConversion) ToStringArray() (strings []string) {
 	totalElements, _ := sac.TotalElements(0)
 	strings = make([]string, totalElements)
 
-	for i := int64(0); i < totalElements; i++ {
+	for i := int32(0); i < totalElements; i++ {
 		strings[int32(i)], _ = safeArrayGetElementString(sac.Array, i)
 	}
 
@@ -25,7 +25,7 @@ func (sac *SafeArrayConversion) ToByteArray() (bytes []byte) {
 	totalElements, _ := sac.TotalElements(0)
 	bytes = make([]byte, totalElements)
 
-	for i := int64(0); i < totalElements; i++ {
+	for i := int32(0); i < totalElements; i++ {
 		safeArrayGetElement(sac.Array, i, unsafe.Pointer(&bytes[int32(i)]))
 	}
 
@@ -37,59 +37,59 @@ func (sac *SafeArrayConversion) ToValueArray() (values []interface{}) {
 	values = make([]interface{}, totalElements)
 	vt, _ := safeArrayGetVartype(sac.Array)
 
-	for i := 0; i < int(totalElements); i++ {
+	for i := int32(0); i < totalElements; i++ {
 		switch VT(vt) {
 		case VT_BOOL:
 			var v bool
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I1:
 			var v int8
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I2:
 			var v int16
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I4:
 			var v int32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I8:
 			var v int64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI1:
 			var v uint8
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI2:
 			var v uint16
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI4:
 			var v uint32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI8:
 			var v uint64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_R4:
 			var v float32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_R8:
 			var v float64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_BSTR:
 			var v string
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_VARIANT:
 			var v VARIANT
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v.Value()
 		default:
 			// TODO
@@ -111,14 +111,14 @@ func (sac *SafeArrayConversion) GetSize() (length *uint32, err error) {
 	return safeArrayGetElementSize(sac.Array)
 }
 
-func (sac *SafeArrayConversion) TotalElements(index uint32) (totalElements int64, err error) {
+func (sac *SafeArrayConversion) TotalElements(index uint32) (totalElements int32, err error) {
 	if index < 1 {
 		index = 1
 	}
 
 	// Get array bounds
-	var LowerBounds int64
-	var UpperBounds int64
+	var LowerBounds int32
+	var UpperBounds int32
 
 	LowerBounds, err = safeArrayGetLBound(sac.Array, index)
 	if err != nil {


### PR DESCRIPTION
The Windows API specs indicate that this should be
a reference to a long value, which is a 32-bit signed
for both Win32 and Win64. This causes problems for an empty array,
then the upper bound is -1 because long(-1) is not
the same as int64(-1). The casting then incorrectly
returns 4294967295 instead of -1 thus failing subsequent
TotalElements() calculation result returning 4294967296 instead of 0.

When using SafeArrayConversion.ToStringArray(),
for example, this results "out of memory" panic.

Signed-off-by: Artur Troian <troian.ap@gmail.com>