### PR TITLE
safeArrayGetElement error when type is VT_BSTR

### DIFF
--- a/safearrayconversion.go
+++ b/safearrayconversion.go
@@ -84,8 +84,7 @@ func (sac *SafeArrayConversion) ToValueArray() (values []interface{}) {
 			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_BSTR:
-			var v string
-			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
+			v , _ := safeArrayGetElementString(sac.Array, i)
 			values[i] = v
 		case VT_VARIANT:
 			var v VARIANT


### PR DESCRIPTION
safeArrayGetElement  points to a BSTR, not golang-string