### PR TITLE
Clear VT_VARIANT inside a SafeArray `.ToValueArray()` conversion

### DIFF
--- a/safearrayconversion.go
+++ b/safearrayconversion.go
@@ -91,6 +91,7 @@ func (sac *SafeArrayConversion) ToValueArray() (values []interface{}) {
 			var v VARIANT
 			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v.Value()
+			v.Clear()
 		default:
 			// TODO
 		}


### PR DESCRIPTION
`SafeArrayGetElement` returns a copy of complex objects (string, object, or variant)
and it's a caller responsibility to clear copied object.

Being not cleared after use `VARIANT` objects cause a leak of OS memory on every
`.ToValueArray()` call.

Ref: https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearraygetelement#remarks

Easy repro with `github.com/bi-zone/wmi@v1.1.3`:

```go
package main

import (
	"log"
	
	"github.com/bi-zone/wmi"
)

func main() {
	type systemProps struct {
		Derivation []string `wmi:"Derivation_"`
	}
	conn, err := wmi.ConnectSWbemServices()
	if err != nil {
		log.Fatalf("Failed to ConnectSWbemServices; %s", err)
	}
	for {
		var wmis []systemProps
		if err := conn.Query("SELECT * FROM Win32_Bios", &wmis); err != nil {
			log.Printf("[ERR] %s", err)
		}
		log.Println(wmis[0])
	}
}
```

System memory will continuously leak (could be tracked by for e.g. Task Manager)