### PR TITLE
Clear EXCEPINFO handling IDispatch.Invoke errors

### DIFF
--- a/idispatch_windows.go
+++ b/idispatch_windows.go
@@ -185,7 +185,9 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 		uintptr(unsafe.Pointer(&excepInfo)),
 		0)
 	if hr != 0 {
-		err = NewErrorWithSubError(hr, BstrToString(excepInfo.bstrDescription), excepInfo)
+		excepInfo.renderStrings()
+		excepInfo.Clear()
+		err = NewErrorWithSubError(hr, excepInfo.description, excepInfo)
 	}
 	for i, varg := range vargs {
 		n := len(params) - i - 1

--- a/ole.go
+++ b/ole.go
@@ -3,6 +3,7 @@ package ole
 import (
 	"fmt"
 	"strings"
+	"unsafe"
 )
 
 // DISPPARAMS are the arguments that passed to methods or property.
@@ -24,6 +25,56 @@ type EXCEPINFO struct {
 	pvReserved        uintptr
 	pfnDeferredFillIn uintptr
 	scode             uint32
+
+	// Go-specific part. Don't move upper cos it'll break structure layout for native code.
+	rendered    bool
+	source      string
+	description string
+	helpFile    string
+}
+
+// renderStrings translates BSTR strings to Go ones so `.Error` and `.String`
+// could be safely called after `.Clear`. We need this when we can't rely on
+// a caller to call `.Clear`.
+func (e *EXCEPINFO) renderStrings() {
+	e.rendered = true
+	if e.bstrSource == nil {
+		e.source = "<nil>"
+	} else {
+		e.source = BstrToString(e.bstrSource)
+	}
+	if e.bstrDescription == nil {
+		e.description = "<nil>"
+	} else {
+		e.description = BstrToString(e.bstrDescription)
+	}
+	if e.bstrHelpFile == nil {
+		e.helpFile = "<nil>"
+	} else {
+		e.helpFile = BstrToString(e.bstrHelpFile)
+	}
+}
+
+// Clear frees BSTR strings inside an EXCEPINFO and set it to NULL.
+func (e *EXCEPINFO) Clear() {
+	freeBSTR := func(s *uint16) {
+		// SysFreeString don't return errors and is safe for call's on NULL.
+		// https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-sysfreestring
+		_ = SysFreeString((*int16)(unsafe.Pointer(s)))
+	}
+
+	if e.bstrSource != nil {
+		freeBSTR(e.bstrSource)
+		e.bstrSource = nil
+	}
+	if e.bstrDescription != nil {
+		freeBSTR(e.bstrDescription)
+		e.bstrDescription = nil
+	}
+	if e.bstrHelpFile != nil {
+		freeBSTR(e.bstrHelpFile)
+		e.bstrHelpFile = nil
+	}
 }
 
 // WCode return wCode in EXCEPINFO.
@@ -38,48 +89,30 @@ func (e EXCEPINFO) SCODE() uint32 {
 
 // String convert EXCEPINFO to string.
 func (e EXCEPINFO) String() string {
-	var src, desc, hlp string
-	if e.bstrSource == nil {
-		src = "<nil>"
-	} else {
-		src = BstrToString(e.bstrSource)
+	if !e.rendered {
+		e.renderStrings()
 	}
-
-	if e.bstrDescription == nil {
-		desc = "<nil>"
-	} else {
-		desc = BstrToString(e.bstrDescription)
-	}
-
-	if e.bstrHelpFile == nil {
-		hlp = "<nil>"
-	} else {
-		hlp = BstrToString(e.bstrHelpFile)
-	}
-
 	return fmt.Sprintf(
 		"wCode: %#x, bstrSource: %v, bstrDescription: %v, bstrHelpFile: %v, dwHelpContext: %#x, scode: %#x",
-		e.wCode, src, desc, hlp, e.dwHelpContext, e.scode,
+		e.wCode, e.source, e.description, e.helpFile, e.dwHelpContext, e.scode,
 	)
 }
 
 // Error implements error interface and returns error string.
 func (e EXCEPINFO) Error() string {
-	if e.bstrDescription != nil {
-		return strings.TrimSpace(BstrToString(e.bstrDescription))
+	if !e.rendered {
+		e.renderStrings()
 	}
 
-	src := "Unknown"
-	if e.bstrSource != nil {
-		src = BstrToString(e.bstrSource)
+	if e.description != "<nil>" {
+		return strings.TrimSpace(e.description)
 	}
 
 	code := e.scode
 	if e.wCode != 0 {
 		code = uint32(e.wCode)
 	}
-
-	return fmt.Sprintf("%v: %#x", src, code)
+	return fmt.Sprintf("%v: %#x", e.source, code)
 }
 
 // PARAMDATA defines parameter data type.


### PR DESCRIPTION
It turned out that we need to clear `EXCEPINFO` `BSTR` fields after use. 

We can't find any documentation
from MS which pointed to that directly, but have found an official sample that does a free:
https://github.com/microsoft/VCSamples/blob/master/VC2010Samples/ATL/OLEDB/Consumer/dbviewer/ErrorDlg.h#L45

Other smart guys that also do the clean up after use by themselves:
1. ECLIPSE: https://github.com/eclipse/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT%20OLE%20Win32/win32/org/eclipse/swt/ole/win32/OleAutomation.java#L694
2. WINE: https://www.winehq.org/pipermail/wine-cvs/2007-July/034631.html


<details>
  <summary>Memory leak repro with github.com/bi-zone/wmi@v1.1.3</summary>
<br>
<b>Being run on Windows machine the following code will noticeably leak a system memory (could be observed e.g. in Task Manager)</b>

```go
package main
import (
	"log"
	"os"
	"os/signal"
	"syscall"
	"time"

	"github.com/bi-zone/wmi"
)

func main() {
	// Subscribe to some rare event. E.g. removal of the local drive.
	const query = "SELECT * FROM Win32_VolumeChangeEvent WHERE EventType=3"

	events := make(chan struct{})
	q, err := wmi.NewNotificationQuery(events, query)
	if err != nil {
		log.Fatalf("Failed to create NotificationQuery; %s", err)
	}

	// Set some really small notification timeout so we will get a lot of timeouts.
	q.SetNotificationTimeout(time.Millisecond)

	// Set exit hook
	sigs := make(chan os.Signal, 1)
	done := make(chan error, 1)
	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

	go func() {
		done <- q.StartNotifications()
	}()

	log.Println("Listening for events ")
	for {
		select {
		case <-events:
			log.Println("Got event!")
		case sig := <-sigs:
			log.Printf("Got system signal %s; stopping", sig)
			q.Stop()
			return
		case err := <-done: // Query will never stop here w/o error.
			log.Printf("[ERR] Got StartNotifications error; %s", err)
			return
		}
	}
}
```
</details>


