### PR TITLE
oleutil: fix ForEach no working as intented

### DIFF
--- a/oleutil/oleutil.go
+++ b/oleutil/oleutil.go
@@ -103,7 +103,7 @@ func MustPutPropertyRef(disp *ole.IDispatch, name string, params ...interface{})
 }
 
 func ForEach(disp *ole.IDispatch, f func(v *ole.VARIANT) error) error {
-	newEnum, err := disp.GetProperty("_NewEnum")
+	newEnum, err := disp.CallMethod("_NewEnum")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`ForEach` loop doesn't work, `disp.GetProperty("_NewEnum")` always returns `nil`. The correct call is `disp.CallMethod("_NewEnum")`