### PR TITLE
add variant_arm64.go

### DIFF
--- a/variant_arm64.go
+++ b/variant_arm64.go
@@ -1,0 +1,12 @@
+// +build arm64
+
+package ole
+
+type VARIANT struct {
+	VT         VT      //  2
+	wReserved1 uint16  //  4
+	wReserved2 uint16  //  6
+	wReserved3 uint16  //  8
+	Val        int64   // 16
+	_          [8]byte // 24
+}


### PR DESCRIPTION
Fixes #216

Test Plan: `GOARCH=arm64 go build`