### PR TITLE
Fix VT_BOOL value conversion

### DIFF
--- a/variant.go
+++ b/variant.go
@@ -99,7 +99,7 @@ func (v *VARIANT) Value() interface{} {
 	case VT_DISPATCH:
 		return v.ToIDispatch()
 	case VT_BOOL:
-		return v.Val != 0
+		return (v.Val & 0xffff) != 0
 	}
 	return nil
 }


### PR DESCRIPTION
boolVal is only 16-bits wide in the C structure, but we are reading it
here as a 64-bit integer. The upper bits are not necessarily
initialized. This can lead to "true" being returned incorrectly when the
actual value is "false".

Fix the issse by masking off the upper bits before the comparison.