### PR TITLE
error.go, idispatch_windows.go: Do a better job of propagating error information from EXCEPINFO.

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,8 +18,8 @@ func NewErrorWithDescription(hr uintptr, description string) *OleError {
 }
 
 // NewErrorWithSubError creates new COM error with parent error.
-func NewErrorWithSubError(hr uintptr, description string, err error) *OleError {
-	return &OleError{hr: hr, description: description, subError: err}
+func NewErrorWithSubError(hr uintptr, err error) *OleError {
+	return &OleError{hr: hr, subError: err}
 }
 
 // Code is the HResult.
@@ -29,8 +29,12 @@ func (v *OleError) Code() uintptr {
 
 // String description, either manually set or format message with error code.
 func (v *OleError) String() string {
+	msg := errstr(int(v.hr))
 	if v.description != "" {
-		return errstr(int(v.hr)) + " (" + v.description + ")"
+		msg += " (" + v.description + ")"
+	}
+	if v.subError != nil {
+		msg += " (" + v.subError.Error() +")"
 	}
 	return errstr(int(v.hr))
 }
@@ -47,5 +51,10 @@ func (v *OleError) Description() string {
 
 // SubError returns parent error, if there is one.
 func (v *OleError) SubError() error {
+	return v.subError
+}
+
+// Unwrap enables OleError to be compabible with the functions in the standard library's errors package
+func (v *OleError) Unwrap() error {
 	return v.subError
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-ole/go-ole
+module github.com/tailscale/go-ole
 
 go 1.12
 

--- a/idispatch_windows.go
+++ b/idispatch_windows.go
@@ -188,7 +188,7 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 	if hr != 0 {
 		excepInfo.renderStrings()
 		excepInfo.Clear()
-		err = NewErrorWithSubError(hr, excepInfo.description, excepInfo)
+		err = NewErrorWithSubError(hr, excepInfo)
 	}
 	for i, varg := range vargs {
 		n := len(params) - i - 1


### PR DESCRIPTION
error.go, idispatch_windows.go: Do a better job of propagating error information from EXCEPINFO.

In go-ole, `OleError` may wrap another error, but it does not surface that information when returning the error string.

This patch adds that error information to the `OleError` string, and also adds an `Unwrap` method.

I also cleaned up the instantiation of this error a bit, as it is redundant to use the inner error's description as the outer error's description now that we're writing out all the things to the message string.