### PR TITLE
native go variant date (#1)

### DIFF
--- a/variant_date_arm64.go
+++ b/variant_date_arm64.go
@@ -5,19 +5,53 @@ package ole
 
 import (
 	"errors"
-	"syscall"
+	"math"
 	"time"
-	"unsafe"
 )
 
-// GetVariantDate converts COM Variant Time value to Go time.Time.
+// Constants representing the valid range of OLE Automation dates
+const (
+	// dates taken from microsoft docs
+	// https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tooadate?view=net-8.0
+	minOleDate float64 = -657434.0        // Represents January 1, 100
+	maxOleDate float64 = 2958465.99999999 // Represents December 31, 9999
+)
+
+// oleStartTime represents the starting point of OLE date calculation (December 30, 1899)
+var oleStartTime = time.Date(1899, 12, 30, 0, 0, 0, 0, time.UTC)
+
+// GetVariantDate converts a uint64 OLE DATE-like value to a Go time.Time structure
 func GetVariantDate(value uint64) (time.Time, error) {
-	var st syscall.Systemtime
-	v1 := uint32(value)
-	v2 := uint32(value >> 32)
-	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(v1), uintptr(v2), uintptr(unsafe.Pointer(&st)))
-	if r != 0 {
-		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
+	// Convert the uint64 back to a float64 (OLE DATE format)
+	oleDateFloat := math.Float64frombits(value)
+
+	// Check if the oleDate is within a valid range
+	if oleDateFloat < minOleDate || oleDateFloat > maxOleDate {
+		return time.Time{}, errors.New("invalid OLE date range")
 	}
-	return time.Now(), errors.New("Could not convert to time, passing current time.")
+
+	// Separate the integer part (days) and the fractional part (time of day)
+	days := int(oleDateFloat)
+	fraction := oleDateFloat - float64(days)
+
+	// Calculate the date by adding the integer part to the oleStartTime
+	date := oleStartTime.AddDate(0, 0, days)
+
+	// fractional component represents the time on that day divided by 24
+	// so mulitplying by 24 gives the total time
+	totalTime := fraction * 24
+
+	hours := int(totalTime)
+	timeUsedInHours := float64(hours)
+
+	minutes := int((totalTime - timeUsedInHours) * 60)
+	timeUsedInMinutes := timeUsedInHours*60 + float64(minutes)
+
+	seconds := int((totalTime*60 - timeUsedInMinutes) * 60)
+	timeUsedInSeconds := timeUsedInMinutes*60 + float64(seconds)
+
+	nanoseconds := int((totalTime*60*60 - timeUsedInSeconds) * 1e9)
+
+	// Construct the final time.Time object, rounded to the nearest millisecond
+	return time.Date(date.Year(), date.Month(), date.Day(), hours, minutes, seconds, nanoseconds, time.UTC).Round(time.Millisecond), nil
 }

--- a/variant_date_arm64_test.go
+++ b/variant_date_arm64_test.go
@@ -1,0 +1,78 @@
+//go:build windows && arm64
+// +build windows,arm64
+
+package ole
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetVariantDate(t *testing.T) {
+	type args struct {
+		value uint64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:    "2023-10-30 23:30:30:000",
+			args:    args{value: math.Float64bits(45229.9795138889)},
+			want:    time.Date(2023, 10, 30, 23, 30, 30, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "2023-10-30 23:30:30:355",
+			args:    args{value: math.Float64bits(45229.979518)},
+			want:    time.Date(2023, 10, 30, 23, 30, 30, 355000000, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "2023-10-30 23:30:30:960",
+			args:    args{value: math.Float64bits(45229.979525)},
+			want:    time.Date(2023, 10, 30, 23, 30, 30, 960000000, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "min OLE date 0100-01-01 0:0:0:000",
+			args:    args{value: math.Float64bits(minOleDate)},
+			want:    time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "max OLE date 9999-12-31 23:59:59:999",
+			args:    args{value: math.Float64bits(maxOleDate)},
+			want:    time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC),
+			wantErr: false,
+		},
+		{
+			name:    "before min date",
+			args:    args{value: math.Float64bits(minOleDate - 1)},
+			want:    time.Time{},
+			wantErr: true,
+		},
+		{
+			name:    "after max date",
+			args:    args{value: math.Float64bits(maxOleDate + 1)},
+			want:    time.Time{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetVariantDate(tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetVariantDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVariantDate() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
GetVariantDate was crashing on arm64 windows when doing when making the modoleaut32.NewProc("VariantTimeToSystemTime") call. I could not figure out how to make work, so implemented a native go function for it.

closes https://github.com/go-ole/go-ole/issues/258