### PR TITLE
Replace deprecated  system's StringToUTF16Ptr

### DIFF
--- a/com.go
+++ b/com.go
@@ -1,11 +1,13 @@
+//go:build windows
 // +build windows
 
 package ole
 
 import (
-	"syscall"
 	"unicode/utf16"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -158,7 +160,7 @@ func CoTaskMemFree(memptr uintptr) {
 // CLSIDFromProgID in Windows API.
 func CLSIDFromProgID(progId string) (clsid *GUID, err error) {
 	var guid GUID
-	lpszProgID := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(progId)))
+	lpszProgID := uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(progId)))
 	hr, _, _ := procCLSIDFromProgID.Call(lpszProgID, uintptr(unsafe.Pointer(&guid)))
 	if hr != 0 {
 		err = NewError(hr)
@@ -175,7 +177,7 @@ func CLSIDFromProgID(progId string) (clsid *GUID, err error) {
 // CLSIDFromString in Windows API.
 func CLSIDFromString(str string) (clsid *GUID, err error) {
 	var guid GUID
-	lpsz := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(str)))
+	lpsz := uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(str)))
 	hr, _, _ := procCLSIDFromString.Call(lpsz, uintptr(unsafe.Pointer(&guid)))
 	if hr != 0 {
 		err = NewError(hr)
@@ -198,7 +200,7 @@ func StringFromCLSID(clsid *GUID) (str string, err error) {
 // IIDFromString returns GUID from program ID.
 func IIDFromString(progId string) (clsid *GUID, err error) {
 	var guid GUID
-	lpsz := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(progId)))
+	lpsz := uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(progId)))
 	hr, _, _ := procIIDFromString.Call(lpsz, uintptr(unsafe.Pointer(&guid)))
 	if hr != 0 {
 		err = NewError(hr)
@@ -266,7 +268,7 @@ func GetObject(programID string, bindOpts *BindOpts, iid *GUID) (unk *IUnknown, 
 		iid = IID_IUnknown
 	}
 	hr, _, _ := procCoGetObject.Call(
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(programID))),
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(programID))),
 		uintptr(unsafe.Pointer(bindOpts)),
 		uintptr(unsafe.Pointer(iid)),
 		uintptr(unsafe.Pointer(&unk)))
@@ -296,7 +298,7 @@ func VariantClear(v *VARIANT) (err error) {
 
 // SysAllocString allocates memory for string and copies string into memory.
 func SysAllocString(v string) (ss *int16) {
-	pss, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(v))))
+	pss, _, _ := procSysAllocString.Call(uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(v))))
 	ss = (*int16)(unsafe.Pointer(pss))
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-ole/go-ole
 
 go 1.12
 
-require golang.org/x/sys v0.1.0
+require golang.org/x/sys v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/idispatch_windows.go
+++ b/idispatch_windows.go
@@ -8,12 +8,14 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 func getIDsOfName(disp *IDispatch, names []string) (dispid []int32, err error) {
 	wnames := make([]*uint16, len(names))
 	for i := 0; i < len(names); i++ {
-		wnames[i] = syscall.StringToUTF16Ptr(names[i])
+		wnames[i] = windows.StringToUTF16Ptr(names[i])
 	}
 	dispid = make([]int32, len(names))
 	namelen := uint32(len(names))

--- a/winrt.go
+++ b/winrt.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package ole
@@ -7,6 +8,8 @@ import (
 	"syscall"
 	"unicode/utf8"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -64,7 +67,7 @@ type HString uintptr
 
 // NewHString returns a new HString for Go string.
 func NewHString(s string) (hstring HString, err error) {
-	u16 := syscall.StringToUTF16Ptr(s)
+	u16 := windows.StringToUTF16Ptr(s)
 	len := uint32(utf8.RuneCountInString(s))
 	hr, _, _ := procWindowsCreateString.Call(
 		uintptr(unsafe.Pointer(u16)),


### PR DESCRIPTION
This PR uses StringToUTF16Ptr from the "golang.org/x/sys/windows" package that is actively maintained.